### PR TITLE
(closed) added CRUD controllers for agit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "deps/rust-sdk"]
 	path = deps/rust-sdk
-	url = git@github.com:biyard/rust-sdk.git
+	url = https://github.com/biyard/rust-sdk.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,7 @@ version = "0.1.0"
 dependencies = [
  "by-axum",
  "by-types",
+ "chrono",
  "models",
  "reqwest",
  "serde",
@@ -608,16 +609,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -4882,6 +4883,12 @@ checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-registry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ license = "Apache-2.0"
 
 [workspace.dependencies]
 # dioxus = { version = "0.6.3" }
-dioxus = { version = "0.6.3", git = "https://github.com/hackartists/dioxus.git" }
+dioxus = { git = "https://github.com/hackartists/dioxus.git" }
 dioxus-web = { version = "0.6.3", git = "https://github.com/hackartists/dioxus.git" }
 
 dioxus-logger = { version = "0.6.2" }

--- a/migrations/20250306114345_init.sql
+++ b/migrations/20250306114345_init.sql
@@ -1,0 +1,49 @@
+-- Add migration script here
+-- Create the `agits` table
+CREATE TABLE IF NOT EXISTS agits (
+    id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    title TEXT NOT NULL
+);
+
+-- Create the `collections` table
+CREATE TABLE IF NOT EXISTS collections (
+    id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    agit_id BIGINT NOT NULL,
+    FOREIGN KEY (agit_id) REFERENCES agits(id) ON DELETE CASCADE
+);
+
+-- Create the `artists` table
+CREATE TABLE IF NOT EXISTS artists (
+    id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    title TEXT NOT NULL
+);
+
+-- Create the `artworks` table
+CREATE TABLE IF NOT EXISTS artworks (
+    id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    agit_id BIGINT NOT NULL,
+    FOREIGN KEY (agit_id) REFERENCES agits(id) ON DELETE CASCADE,
+    collection_id BIGINT NOT NULL,
+    FOREIGN KEY (collection_id) REFERENCES collections(id) ON DELETE CASCADE,
+    artist_id BIGINT NOT NULL,
+    FOREIGN KEY (artist_id) REFERENCES artists(id) ON DELETE CASCADE
+);
+
+-- Create the function to set `created_at` before insert
+CREATE OR REPLACE FUNCTION set_created_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.created_at := NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create th

--- a/packages/api/Cargo.toml
+++ b/packages/api/Cargo.toml
@@ -24,6 +24,7 @@ sqlx = { version = "0.8.3", features = [
 ] }
 
 models = { workspace = true, features = ["server"] }
+chrono = "0.4.40"
 [features]
 default = []
 server = []

--- a/packages/api/src/controllers/v1/agit/mod.rs
+++ b/packages/api/src/controllers/v1/agit/mod.rs
@@ -1,0 +1,87 @@
+use by_axum::{aide::axum::IntoApiResponse, axum::{http::StatusCode, routing::{get, post}, Router}};
+use by_axum::axum::{extract::{Json, Path}, response::IntoResponse, Extension};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use models::v1::agit::{AgitRepository, AgitQuery, AgitReadAction, AgitRepositoryUpdateRequest};
+
+#[derive(Deserialize, Serialize)]
+pub struct CreateAgit {
+    pub title: String,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct UpdateAgit {
+    pub title: String,
+}
+
+pub async fn create_agit(
+    Json(payload): Json<CreateAgit>,
+    Extension(repo): Extension<Arc<AgitRepository>>,
+) -> impl IntoApiResponse {
+    match repo.insert(payload.title).await {
+        Ok(agit) => (StatusCode::CREATED, Json(agit)).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(format!("Failed to create agit: {}", e))).into_response(),
+    }
+}
+
+pub async fn get_agits(
+    Extension(repo): Extension<Arc<AgitRepository>>,
+) -> impl IntoApiResponse {
+    let query = AgitQuery { 
+        size: 10, 
+        bookmark: None, 
+    };
+
+    match repo.find(&query).await {
+        Ok(agits) => (StatusCode::OK, Json(agits)).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(format!("Failed to retrieve agits: {}", e))).into_response(),
+    }
+}
+
+pub async fn get_agit_by_id(
+    Path(id): Path<i64>,
+    Extension(repo): Extension<Arc<AgitRepository>>,
+) -> impl IntoApiResponse {
+    let query = AgitReadAction {
+        // id: id, #TODO
+    };
+
+    match repo.find_one(&query).await {
+        Ok(agit) => (StatusCode::OK, Json(agit)).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(format!("Failed to retrieve agit: {}", e))).into_response(),
+    }
+}
+
+pub async fn update_agit(
+    Path(id): Path<i64>,
+    Json(payload): Json<UpdateAgit>,
+    Extension(repo): Extension<Arc<AgitRepository>>,
+) -> impl IntoResponse {    
+    let update_request = AgitRepositoryUpdateRequest {
+        title: Some(payload.title),
+    };
+
+    match repo.update(id, update_request).await {
+        Ok(updated_agit) => (StatusCode::OK, Json(updated_agit)).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(format!("Failed to update agit: {}", e))).into_response(),
+    }
+}
+
+pub async fn delete_agit(
+    Path(id): Path<i64>,
+    Extension(repo): Extension<Arc<AgitRepository>>,
+) -> impl IntoApiResponse {
+    match repo.delete(id).await {
+        Ok(_) => (StatusCode::NO_CONTENT).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(format!("Failed to delete agit: {}", e))).into_response(),
+    }
+}
+
+pub fn router() -> Router {
+    Router::new()
+        .route("/v1/agits", post(create_agit)) 
+        .route("/v1/agits", get(get_agits))  
+        .route("/v1/agits/:id", get(get_agit_by_id))  
+        .route("/v1/agits/update/:id", post(update_agit))  
+        .route("/v1/agits/delete/:id", post(delete_agit)) 
+}

--- a/packages/api/src/controllers/v1/mod.rs
+++ b/packages/api/src/controllers/v1/mod.rs
@@ -1,12 +1,16 @@
+pub mod agit;
+
 use sqlx::{postgres::PgPoolOptions, Pool, Postgres};
 
 pub fn routes(pool: Pool<Postgres>) -> models::Result<by_axum::router::BiyardRouter> {
     Ok((by_axum::router::BiyardRouter::new())
-        .nest("/agits", controllers::v1::agit::routes(pool.clone())?)
-        .nest("/artists", controllers::v1::artist::routes(pool.clone())?)
-        .nest("/artworks", controllers::v1::artwork::routes(pool.clone())?)
-        .nest(
-            "/collections",
-            controllers::v1::collection::routes(pool.clone())?,
-        ))
+        .nest("/agits", agit::router())
+
+        // .nest("/artists", controllers::v1::artist::routes(pool.clone())?)
+        // .nest("/artworks", controllers::v1::artwork::routes(pool.clone())?)
+        // .nest(
+        //     "/collections",
+        //     controllers::v1::collection::routes(pool.clone())?,
+        // )
+    )
 }

--- a/packages/api/src/main.rs
+++ b/packages/api/src/main.rs
@@ -4,7 +4,7 @@ pub mod controllers;
 use controllers::v1;
 
 use by_types::DatabaseConfig;
-use models::{agit::Agit, artist::Artist, artwork::Artwork, collection::Collection};
+use models::v1::{agit::Agit, artist::Artist, artwork::Artwork, collection::Collection};
 use sqlx::postgres::PgPoolOptions;
 use tokio::net::TcpListener;
 

--- a/packages/build-ui/src/main.rs
+++ b/packages/build-ui/src/main.rs
@@ -10,7 +10,7 @@ use routes::Route;
 
 const FAVICON: Asset = asset!("/public/favicon.svg");
 const MAIN_CSS: Asset = asset!("/public/main.css");
-const TAILWIND_CSS: Asset = asset!("/public/tailwind.css");
+const TAILWIND_CSS: Asset = asset!("/public/main.css");
 
 fn main() {
     dioxus_logger::init(config::get().log_level).expect("failed to init logger");


### PR DESCRIPTION
Added the controllers and used the AgitRepository;

Had trait-bound Issues with the create_agit and update_agit controllers in the router, I commented them out and the router ran.

The db wasn't running due to a type error for "created_at", so I ran a migration for that.

I am requesting a review of those two functions. 

@RyanCho-0 @hackartists 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new REST API endpoints for managing content entities.
  - Implemented a database migration to establish enhanced data structures for content management.

- **Refactor**
  - Streamlined routing logic and updated import paths to support versioned API handling.

- **Chores**
  - Updated external dependency and submodule references.
  - Revised asset configuration for UI styling consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->