### PR TITLE
view nft table->enabled lang on every component

### DIFF
--- a/packages/build-ui/src/pages/agits/_id/management/collectors/_id/components/activity_table.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/collectors/_id/components/activity_table.rs
@@ -1,9 +1,10 @@
-use crate::pages::agits::_id::management::collectors::models::Activity;
+use crate::pages::agits::_id::management::collectors::{i18n::CollectorsTranslate, models::Activity};
 use bdk::prelude::*;
 
 #[component]
 #[allow(unused_variables)]
-pub fn render_activity_table(activity: Vec<Activity>) -> Element {
+pub fn render_activity_table(activity: Vec<Activity>, lang: Language) -> Element {
+    let tr: CollectorsTranslate = translate(&lang);
     rsx! {
                 { activity.iter().enumerate().map(|(index, activity)| {
 

--- a/packages/build-ui/src/pages/agits/_id/management/collectors/_id/components/activity_table.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/collectors/_id/components/activity_table.rs
@@ -3,7 +3,7 @@ use bdk::prelude::*;
 
 #[component]
 #[allow(unused_variables)]
-pub fn render_activity_table(activity: Vec<Activity>, lang: Language) -> Element {
+pub fn ActivityTable(activity: Vec<Activity>, lang: Language) -> Element {
     let tr: CollectorsTranslate = translate(&lang);
     rsx! {
                 { activity.iter().enumerate().map(|(index, activity)| {

--- a/packages/build-ui/src/pages/agits/_id/management/collectors/_id/components/created_table.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/collectors/_id/components/created_table.rs
@@ -1,11 +1,12 @@
-use crate::pages::agits::_id::management::collectors::models::Asset;
+use crate::pages::agits::_id::management::collectors::{i18n::CollectorsTranslate, models::Asset};
 use bdk::prelude::{
     by_components::icons::{arrows, validations},
     *,
 };
 
 #[component]
-pub fn render_created_table(assets: Vec<Asset>) -> Element {
+pub fn render_created_table(assets: Vec<Asset>, lang:Language) -> Element {
+    let tr: CollectorsTranslate = translate(&lang);
     rsx! {
             table {
                 class: "w-full text-sm text-left border-collapse min-w-[800px]",
@@ -14,61 +15,61 @@ pub fn render_created_table(assets: Vec<Asset>) -> Element {
 
                         th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
                           div { class: "flex items-center",
-                             span {"Title"}
+                             span {{tr.title}}
                               arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
                            }
                         }
                         th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
                           div { class: "flex items-center",
-                             span {"Attributes"}
+                             span {{tr.attributes}}
                             //   arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
                            }
                         }
                         th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
                           div { class: "flex items-center",
-                             span {"Ways to Sell"}
+                             span {{tr.ways_to_sell}}
                               arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
                            }
                         }
                         th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
                           div { class: "flex items-center",
-                             span {"Owner"}
+                             span {{tr.owner}}
                               arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
                            }
                         }
                         th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
                           div { class: "flex items-center",
-                             span {"Current Price"}
+                             span {{tr.current_price}}
                               arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
                            }
                         }
                         th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
                           div { class: "flex items-center",
-                             span {"Average Price"}
+                             span {{tr.average_price}}
                               arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
                            }
                         }
                         th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
                           div { class: "flex items-center",
-                             span {"Price Change"}
+                             span {{tr.price_change}}
                               arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
                            }
                         }
                         th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
                           div { class: "flex items-center",
-                             span {"Volume"}
+                             span {{tr.volume}}
                               arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
                            }
                         }
                         th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
                           div { class: "flex items-center",
-                             span {"Royalty"}
+                             span {{tr.royalty}}
                               arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
                            }
                         }
                         th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
                           div { class: "flex items-center",
-                             span {"Status"}
+                             span {{tr.status}}
                               arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
                            }
                         }

--- a/packages/build-ui/src/pages/agits/_id/management/collectors/_id/components/created_table.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/collectors/_id/components/created_table.rs
@@ -5,7 +5,7 @@ use bdk::prelude::{
 };
 
 #[component]
-pub fn render_created_table(assets: Vec<Asset>, lang:Language) -> Element {
+pub fn CreatedTable(assets: Vec<Asset>, lang:Language) -> Element {
     let tr: CollectorsTranslate = translate(&lang);
     rsx! {
             table {

--- a/packages/build-ui/src/pages/agits/_id/management/collectors/_id/components/mod.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/collectors/_id/components/mod.rs
@@ -2,9 +2,11 @@ pub mod activity_table;
 pub mod owned_table;
 pub mod trade_table;
 pub mod created_table;
+pub mod nft_images;
 
 pub use activity_table::render_activity_table;
 pub use owned_table::render_owned_table;
 pub use trade_table::render_trade_table;
 pub use created_table::render_created_table;
+pub use nft_images::render_nft_images;
 

--- a/packages/build-ui/src/pages/agits/_id/management/collectors/_id/components/mod.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/collectors/_id/components/mod.rs
@@ -4,9 +4,9 @@ pub mod trade_table;
 pub mod created_table;
 pub mod nft_images;
 
-pub use activity_table::render_activity_table;
-pub use owned_table::render_owned_table;
-pub use trade_table::render_trade_table;
-pub use created_table::render_created_table;
-pub use nft_images::render_nft_images;
+pub use activity_table::ActivityTable;
+pub use owned_table::OwnedTable;
+pub use trade_table::TradeTable;
+pub use created_table::CreatedTable;
+pub use nft_images::NftTable;
 

--- a/packages/build-ui/src/pages/agits/_id/management/collectors/_id/components/nft_images.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/collectors/_id/components/nft_images.rs
@@ -2,7 +2,7 @@
 use bdk::prelude::{by_components::icons::validations, *};
 use crate::pages::agits::_id::management::collectors::{i18n::CollectorsTranslate, models::Asset};
 #[component]
-pub fn render_nft_images(assets: Vec<Asset>, lang:Language) -> Element {
+pub fn NftTable(assets: Vec<Asset>, lang:Language) -> Element {
     let tr: CollectorsTranslate = translate(&lang);
     rsx! {
         div {

--- a/packages/build-ui/src/pages/agits/_id/management/collectors/_id/components/nft_images.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/collectors/_id/components/nft_images.rs
@@ -1,0 +1,86 @@
+#[allow(unused_imports)]
+use bdk::prelude::{by_components::icons::validations, *};
+use crate::pages::agits::_id::management::collectors::{i18n::CollectorsTranslate, models::Asset};
+#[component]
+pub fn render_nft_images(assets: Vec<Asset>, lang:Language) -> Element {
+    let tr: CollectorsTranslate = translate(&lang);
+    rsx! {
+        div {
+            class: "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 align-items-start",
+            
+            {assets.iter().enumerate().map(|(index, asset)| {
+                let dimensions = if index % 2 == 0 {
+                    "width: 342px; height: 500px;"
+                } else {
+                    "width: 342px; height: 350px;"
+                };
+                rsx! {
+                    div {
+                        key: "{asset.id}",
+                        class: "overflow-hidden hover:border-gray-600 transition-all duration-200 flex flex-col",
+                        // Image container
+                        div {
+                            class: "relative bg-gray-800",
+                            style: "{dimensions}",
+                           
+                                div {
+                                    class: "text-4xl text-gray-600 absolute inset-0 flex items-center justify-center",
+                                    img {
+                                        class: "w-full h-full object-cover",
+                                        src: asset.art_image.clone()
+                                    }
+                                
+                            }
+                        }
+                        // NFT metadata section
+                        div {
+                            class: "py-4 text-white flex-shrink-0",
+                            // Title and tag
+                            div {
+                                class: "flex items-center mb-2",
+                                span {
+                                    class: "text-lg font-semibold",
+                                    {asset.title.clone()}
+                                }
+                                span {
+                                    class: "ml-2 text-sm border border-gray-600 px-2 py-1",
+                                    "TAG"
+                                }
+                            }
+                            // Artist name
+                            div {
+                                class: "text-sm text-gray-400 mb-2",
+                                "by {asset.artist_name}"
+                            }
+                            // Price, Sales Volume, and Owners
+                            div {
+                                class: "flex justify-between text-gray-400  text-sm",
+                                div{ class: "flex flex-col",
+                                    div {
+                                        {tr.current_price}
+                                    }
+                                    span {class: "font-bold text-white", "${asset.current_price}" }
+                                }
+                                div{ 
+                                    class: "flex flex-col",
+
+                                    div {
+                                       {tr.sales_volume}
+                                    }
+                                    span {class: "font-bold text-white", "${asset.volume}"  }
+                                }
+                                div{class: "flex flex-col",
+
+                                    div {
+                                        {tr.owner}
+                                    }
+                                    span{class: "font-bold text-white", "{asset.owner}" }
+                                }
+                            }
+                        }
+                    }
+                }
+            })}
+        }
+    }
+}

--- a/packages/build-ui/src/pages/agits/_id/management/collectors/_id/components/owned_table.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/collectors/_id/components/owned_table.rs
@@ -1,11 +1,12 @@
-use crate::pages::agits::_id::management::collectors::models::Asset;
+use crate::pages::agits::_id::management::collectors::{i18n::CollectorsTranslate, models::Asset};
 use bdk::prelude::{
     by_components::icons::{arrows, validations},
     *,
 };
 
 #[component]
-pub fn render_owned_table(assets: Vec<Asset>) -> Element {
+pub fn render_owned_table(assets: Vec<Asset>, lang:Language) -> Element {
+    let tr: CollectorsTranslate = translate(&lang);
     rsx! {
             table {
                 class: "w-full text-sm text-left border-collapse min-w-[800px]",
@@ -14,61 +15,61 @@ pub fn render_owned_table(assets: Vec<Asset>) -> Element {
 
                         th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
                           div { class: "flex items-center",
-                             span {"Title"}
+                             span {{tr.title}}
                               arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
                            }
                         }
                         th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
                           div { class: "flex items-center",
-                             span {"Attributes"}
+                             span {{tr.attributes}}
                             //   arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
                            }
                         }
                         th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
                           div { class: "flex items-center",
-                             span {"Ways to Sell"}
+                             span {{tr.ways_to_sell}}
                               arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
                            }
                         }
                         th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
                           div { class: "flex items-center",
-                             span {"Owner"}
+                             span {{tr.owner}}
                               arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
                            }
                         }
                         th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
                           div { class: "flex items-center",
-                             span {"Current Price"}
+                             span {{tr.current_price}}
                               arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
                            }
                         }
                         th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
                           div { class: "flex items-center",
-                             span {"Average Price"}
+                             span {{tr.average_price}}
                               arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
                            }
                         }
                         th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
                           div { class: "flex items-center",
-                             span {"Price Change"}
+                             span {{tr.price_change}}
                               arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
                            }
                         }
                         th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
                           div { class: "flex items-center",
-                             span {"Volume"}
+                             span {{tr.volume}}
                               arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
                            }
                         }
                         th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
                           div { class: "flex items-center",
-                             span {"Royalty"}
+                             span {{tr.royalty}}
                               arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
                            }
                         }
                         th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
                           div { class: "flex items-center",
-                             span {"Status"}
+                             span {{tr.status}}
                               arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
                            }
                         }
@@ -222,5 +223,5 @@ pub fn render_owned_table(assets: Vec<Asset>) -> Element {
                  })}
              }
          }
-    }
+     }
 }

--- a/packages/build-ui/src/pages/agits/_id/management/collectors/_id/components/owned_table.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/collectors/_id/components/owned_table.rs
@@ -5,7 +5,7 @@ use bdk::prelude::{
 };
 
 #[component]
-pub fn render_owned_table(assets: Vec<Asset>, lang:Language) -> Element {
+pub fn OwnedTable(assets: Vec<Asset>, lang:Language) -> Element {
     let tr: CollectorsTranslate = translate(&lang);
     rsx! {
             table {

--- a/packages/build-ui/src/pages/agits/_id/management/collectors/_id/components/trade_table.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/collectors/_id/components/trade_table.rs
@@ -1,86 +1,86 @@
-use crate::pages::agits::_id::management::collectors::models::Asset;
+use crate::pages::agits::_id::management::collectors::{i18n::CollectorsTranslate, models::Asset};
 use bdk::prelude::{
     by_components::icons::{arrows, validations},
     *,
 };
 
 #[component]
-pub fn render_trade_table(assets: Vec<Asset>) -> Element {
+pub fn render_trade_table(assets: Vec<Asset>, lang:Language) -> Element {
+    let tr: CollectorsTranslate = translate(&lang);
     rsx! {
             table {
                 class: "w-full text-sm text-left border-collapse min-w-[800px]",
                 thead {
                     tr {
-
                         th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
-                          div { class: "flex items-center",
-                             span {"Title"}
-                              arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
-                           }
-                        }
-                        th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
-                          div { class: "flex items-center",
-                             span {"Attributes"}
-                            //   arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
-                           }
-                        }
-                        th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
-                          div { class: "flex items-center",
-                             span {"Ways to Sell"}
-                              arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
-                           }
-                        }
-                        th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
-                          div { class: "flex items-center",
-                             span {"Owner"}
-                              arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
-                           }
-                        }
-                        th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
-                          div { class: "flex items-center",
-                             span {"Current Price"}
-                              arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
-                           }
-                        }
-                        th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
-                          div { class: "flex items-center",
-                             span {"Average Price"}
-                              arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
-                           }
-                        }
-                        th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
-                          div { class: "flex items-center",
-                             span {"Price Change"}
-                              arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
-                           }
-                        }
-                        th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
-                          div { class: "flex items-center",
-                             span {"Volume"}
-                              arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
-                           }
-                        }
-                        th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
-                          div { class: "flex items-center",
-                             span {"Royalty"}
-                              arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
-                           }
-                        }
-                        th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
-                          div { class: "flex items-center",
-                             span {"Status"}
-                              arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
-                           }
-                        }
-                       th { class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
                         div { class: "flex items-center",
-                            span { "" }
-                            validations::Extra { class: "[&>circle]:stroke-white", height:18 }
-                        }
-                    }
+                           span {{tr.title}}
+                            arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
+                         }
+                      }
+                      th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
+                        div { class: "flex items-center",
+                           span {{tr.attributes}}
+                          //   arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
+                         }
+                      }
+                      th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
+                        div { class: "flex items-center",
+                           span {{tr.ways_to_sell}}
+                            arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
+                         }
+                      }
+                      th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
+                        div { class: "flex items-center",
+                           span {{tr.owner}}
+                            arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
+                         }
+                      }
+                      th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
+                        div { class: "flex items-center",
+                           span {{tr.current_price}}
+                            arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
+                         }
+                      }
+                      th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
+                        div { class: "flex items-center",
+                           span {{tr.average_price}}
+                            arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
+                         }
+                      }
+                      th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
+                        div { class: "flex items-center",
+                           span {{tr.price_change}}
+                            arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
+                         }
+                      }
+                      th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
+                        div { class: "flex items-center",
+                           span {{tr.volume}}
+                            arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
+                         }
+                      }
+                      th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
+                        div { class: "flex items-center",
+                           span {{tr.royalty}}
+                            arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
+                         }
+                      }
+                      th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
+                        div { class: "flex items-center",
+                           span {{tr.status}}
+                            arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
+                         }
+                      }
+                     th { class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
+                      div { class: "flex items-center",
+                          span { "" }
+                          validations::Extra { class: "[&>circle]:stroke-white", height:18 }
+                      }
+                  }
 
-                    }
-                }
+                  }
+              }
             tbody {
                 { assets.iter().enumerate().map(|(index, asset)| {
                      rsx! {

--- a/packages/build-ui/src/pages/agits/_id/management/collectors/_id/components/trade_table.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/collectors/_id/components/trade_table.rs
@@ -5,7 +5,7 @@ use bdk::prelude::{
 };
 
 #[component]
-pub fn render_trade_table(assets: Vec<Asset>, lang:Language) -> Element {
+pub fn TradeTable(assets: Vec<Asset>, lang:Language) -> Element {
     let tr: CollectorsTranslate = translate(&lang);
     rsx! {
             table {

--- a/packages/build-ui/src/pages/agits/_id/management/collectors/_id/page.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/collectors/_id/page.rs
@@ -1,7 +1,7 @@
 use crate::{
     pages::agits::_id::management::collectors::{
         _id::components::{
-            render_activity_table, render_created_table, render_nft_images, render_owned_table, render_trade_table
+            ActivityTable, CreatedTable, NftTable, OwnedTable, TradeTable
         },
         controllers::Controller, i18n::CollectorsTranslate,
     },
@@ -324,29 +324,29 @@ pub fn CollectorDetailPage(
                                 AssetTab::Owned=> {
                                     if *view_mode.read()=="nftImages" {
                                         rsx!{
-                                            render_nft_images {assets: assets.clone(), lang}
+                                            NftTable {assets: assets.clone(), lang}
                                         }
                                     }else {
-                                    rsx!{ render_owned_table {assets: assets.clone(), lang}} 
+                                    rsx!{ OwnedTable {assets: assets.clone(), lang}} 
                                } 
                             }
                             AssetTab::Created => {
                                 if *view_mode.read() == "nftImages" {
-                                    rsx!{ render_nft_images { assets: assets.clone(), lang} }
+                                    rsx!{ NftTable { assets: assets.clone(), lang} }
                                 } else {
-                                    rsx!{ render_created_table { assets: assets.clone(), lang } }
+                                    rsx!{ CreatedTable { assets: assets.clone(), lang } }
                                 }
                             },
                             AssetTab::Trade => {
                                 if *view_mode.read() == "nftImages" {
-                                    rsx!{ render_nft_images { assets: assets.clone(), lang } }
+                                    rsx!{ NftTable { assets: assets.clone(), lang } }
                                 } else {
-                                    rsx!{ render_trade_table { assets: assets.clone(), lang } }
+                                    rsx!{ TradeTable { assets: assets.clone(), lang } }
                                 }
                             },
                             AssetTab::Activity => {
                                 // Activity is always shown as a table
-                                rsx!{ render_activity_table { activity: activities.clone(), lang  } }
+                                rsx!{ ActivityTable { activity: activities.clone(), lang  } }
                             },
                             }}
 

--- a/packages/build-ui/src/pages/agits/_id/management/collectors/_id/page.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/collectors/_id/page.rs
@@ -1,9 +1,9 @@
 use crate::{
     pages::agits::_id::management::collectors::{
         _id::components::{
-            render_activity_table, render_created_table, render_owned_table, render_trade_table,
+            render_activity_table, render_created_table, render_nft_images, render_owned_table, render_trade_table
         },
-        controllers::Controller,
+        controllers::Controller, i18n::CollectorsTranslate,
     },
     routes::Route,
 };
@@ -26,12 +26,14 @@ pub fn CollectorDetailPage(
     collector_id: i64,
 ) -> Element {
     let search_query = use_signal(String::new);
-    let view_mode = use_signal(|| "grid");
+    let mut view_mode = use_signal(|| "table"); 
     let filter = use_signal(|| "All");
+    let tr: CollectorsTranslate = translate(&lang);
     let ctrl = Controller::new(lang, agit_id)?;
     let assets = ctrl.asset();
     let activities = ctrl.activity();
     let mut active_tab = use_signal(|| AssetTab::Owned);
+
     rsx! {
              div{
                 class: "w-full min-h-screen bg-background h-full flex text-white justify-center items-center",
@@ -114,7 +116,7 @@ pub fn CollectorDetailPage(
                 div {
                     // Stat
                     div { class: "border-b-2 border-border-primary flex justify-between items-center pb-2  mb-4",
-                        p { class: "text-sm text-white", "Total Volume" }
+                        p { class: "text-sm text-white", {tr.total_volume} }
                         p { class: "text-sm font-bold", "2,370 ETH" }
                     }
                     // Wallet
@@ -127,12 +129,12 @@ pub fn CollectorDetailPage(
                 div {
                     // Stat
                     div { class: "border-b-2 border-border-primary flex justify-between items-center pb-2 mb-4",
-                        p { class: "text-sm text-white", "Owned" }
+                        p { class: "text-sm text-white", {tr.owned} }
                         p { class: "text-sm font-bold", "2,370 ETH" }
                     }
                     // Wallet
                     div { class: "pt-2 border-b-2 border-border-primary flex justify-between items-center pb-2 mt-4",
-                        p { class: "text-sm text-white", "Wallet Address" }
+                        p { class: "text-sm text-white", {tr.wallet_address} }
                         div { class: "flex items-center",
                             p { class: "font-mono text-sm", "0x1234...abcd" }
                             button { class: "ml-2 text-white",
@@ -157,12 +159,12 @@ pub fn CollectorDetailPage(
                 div {
                     // Stat
                     div { class: "border-b-2 border-border-primary flex justify-between items-center pb-2 mb-4",
-                        p { class: "text-sm text-white", "Owned" }
+                        p { class: "text-sm text-white", {tr.owned} }
                         p { class: "text-sm font-bold", "2,370 ETH" }
                     }
                     // Wallet
                     div { class: "pt-2 border-b-2 border-border-primary flex justify-between items-center pb-2 mt-4",
-                        p { class: "text-sm text-white", "Wallet Address" }
+                        p { class: "text-sm text-white", {tr.wallet_address} }
                         div { class: "flex items-center",
                             p { class: "font-mono text-sm", "0x1234...abcd" }
                             button { class: "ml-2 text-white",
@@ -258,19 +260,32 @@ pub fn CollectorDetailPage(
                         // View mode buttons
                         div {
                             class: "flex space-x-2",
-                            button {
-                                class: "p-2 border border-border-primary text-white w-full sm:w-auto",
-                                // onclick: move |_| show_filters.toggle(),
-                                layouts::Window{ class: "[&>path]:stroke-white" }
-                            }
 
 
-                            // Filter dropdown
-                            button {
-                                class: "p-2 border border-border-primary text-white w-full sm:w-auto",
-                                // onclick: move |_| show_filters.toggle(),
-                                settings::Sliders { class: "[&>path]:stroke-white" }
-                            }
+
+                                 // Filter dropdown
+                                 button {
+                                    class: "p-2 border border-border-primary text-white w-full sm:w-auto",
+                                    // onclick: move |_| show_filters.toggle(),
+                                    settings::Sliders { class: "[&>path]:stroke-white" }
+                                }
+
+                                button {
+                                    class: format!("p-2 border {} text-white w-full sm:w-auto", 
+                                        if *view_mode.read() == "nftImages" { "border-white" } else { "border-border-primary" }
+                                    ),
+                                    onclick: move |_| {
+                                        if *view_mode.read() == "table" {
+                                            view_mode.set("nftImages");
+                                        } else {
+                                            view_mode.set("table");
+                                        }
+                                    },
+                                    layouts::Window{ class: "[&>path]:stroke-white" }
+                                }
+
+
+                       
 
                             // All dropdown
                             div { class: "relative",
@@ -306,18 +321,33 @@ pub fn CollectorDetailPage(
 
 
                             {match active_tab.with(|tab| tab.clone()) {
-                                AssetTab::Owned=> rsx!{
-                                    render_owned_table {assets: assets.clone()}
-                                },
-                                AssetTab::Created=> rsx!{
-                                    render_created_table {assets: assets.clone()}
-                                },
-                                AssetTab::Trade=> rsx!{
-                                    render_trade_table {assets: assets.clone()}
-                                },
-                                AssetTab::Activity=> rsx!{
-                                    render_activity_table {activity: activities.clone()}
-                                },
+                                AssetTab::Owned=> {
+                                    if *view_mode.read()=="nftImages" {
+                                        rsx!{
+                                            render_nft_images {assets: assets.clone(), lang}
+                                        }
+                                    }else {
+                                    rsx!{ render_owned_table {assets: assets.clone(), lang}} 
+                               } 
+                            }
+                            AssetTab::Created => {
+                                if *view_mode.read() == "nftImages" {
+                                    rsx!{ render_nft_images { assets: assets.clone(), lang} }
+                                } else {
+                                    rsx!{ render_created_table { assets: assets.clone(), lang } }
+                                }
+                            },
+                            AssetTab::Trade => {
+                                if *view_mode.read() == "nftImages" {
+                                    rsx!{ render_nft_images { assets: assets.clone(), lang } }
+                                } else {
+                                    rsx!{ render_trade_table { assets: assets.clone(), lang } }
+                                }
+                            },
+                            AssetTab::Activity => {
+                                // Activity is always shown as a table
+                                rsx!{ render_activity_table { activity: activities.clone(), lang  } }
+                            },
                             }}
 
 

--- a/packages/build-ui/src/pages/agits/_id/management/collectors/controllers.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/collectors/controllers.rs
@@ -42,7 +42,7 @@ impl Controller{
         artist_name: "Artist Name".to_string(),
         attributes: vec!["Pixel".to_string(), "Animation".to_string()],
         way_to_sell: "Offer".to_string(),
-        owner: "Num".to_string(),
+        owner: "247".to_string(),
         current_price: 2.370,
         current_price_usd: 8147.63,
         average_price: 2.370,
@@ -55,6 +55,7 @@ impl Controller{
         royalty_usd: 8147.63,
         status: "Active".to_string(),
         verified: true,
+        art_image: "https://res.cloudinary.com/dgesrup3u/image/upload/v1744880242/Screenshot_2025-04-17_at_9.56.47_AM_ll2cwy.png".to_string(),
 
     }).collect::<Vec<_>>()
  });

--- a/packages/build-ui/src/pages/agits/_id/management/collectors/i18n.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/collectors/i18n.rs
@@ -20,7 +20,10 @@ translate! {
         en: "Total Volume",
         ko: "총 거래량",
     },
-
+    title:{
+        en: "Title",
+        ko: "제목",
+    }
     owned: {
         en: "Owned",
         ko: "소유한",
@@ -69,6 +72,10 @@ translate! {
         en: "Volume",
         ko: "거래량",
     }
+    sales_volume:{
+        en: "Sales Volume",
+        ko: "판매량",
+    }
     royalty:{
         en: "Royalty",
         ko: "로열티",
@@ -89,4 +96,5 @@ translate! {
         en: "Search by title",
         ko: "제목으로 검색",
     }
+    
 }

--- a/packages/build-ui/src/pages/agits/_id/management/collectors/models.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/collectors/models.rs
@@ -31,6 +31,7 @@ pub struct Asset {
     pub royalty_usd: f64,
     pub status: String,
     pub verified: bool,
+    pub art_image: String,
 }
 
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a toggle to switch between table and NFT image grid views for asset tabs, enhancing asset browsing options.
  - Introduced a new NFT image grid display with responsive layout and localized metadata for assets.
- **Localization**
  - Table headers and UI labels are now fully localized based on language selection, including new translations for "Title" and "Sales Volume".
- **Improvements**
  - Asset data now includes NFT art images and updated owner information for a richer display experience.
  - Component names and signatures updated for consistency and to support localization parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->