### PR TITLE
edit artist page added

### DIFF
--- a/packages/build-ui/src/pages/agits/_id/management/artists/_id/components/artist_table.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/_id/components/artist_table.rs
@@ -1,9 +1,10 @@
 use crate::pages::agits::_id::management::artists::i18n::ArtistTranslate;
 use crate::pages::agits::_id::management::model::Assets;
+use crate::routes::Route;
 use bdk::prelude::by_components::icons::arrows;
 use bdk::prelude::{by_components::icons::validations, *};
 #[component]
-pub fn ArtistTable(assets: Vec<Assets>     ,lang: Language) -> Element {
+pub fn ArtistTable(assets: Vec<Assets> ,lang: Language, agit_id: ReadOnlySignal<i64>, artist_id:i64) -> Element {
     let mut active_dropdown = use_signal(|| None::<usize>);
 
   let tr: ArtistTranslate= translate(&lang);
@@ -79,12 +80,20 @@ pub fn ArtistTable(assets: Vec<Assets>     ,lang: Language) -> Element {
                 }
             }
             tbody {
-                { assets.iter().enumerate().map(|(index, asset)| {
+                { assets.into_iter().enumerate().map(|(index, asset)| {
                     let is_dropdown_open = active_dropdown.with(|active| active == &Some(index));
                     rsx! {
                         tr {
                             key: "owned-tr-{index}",
                             class: "border-b border-gray-800 hover:bg-gray-900",
+                            onclick: move |_| {
+                             
+                                use_navigator().push(Route::EditArtistPage { 
+                                    lang: lang, 
+                                    agit_id: agit_id(), 
+                                    artist_id: artist_id
+                                });
+                            },
                             td {
                                 class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
                                 div {

--- a/packages/build-ui/src/pages/agits/_id/management/artists/_id/components/artist_table.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/_id/components/artist_table.rs
@@ -93,6 +93,7 @@ pub fn ArtistTable(assets: Vec<Assets> ,lang: Language, agit_id: ReadOnlySignal<
                                     agit_id: agit_id(), 
                                     artist_id: artist_id
                                 });
+                                // on_asset_click.call(agit_id, artist_id);
                             },
                             td {
                                 class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",

--- a/packages/build-ui/src/pages/agits/_id/management/artists/_id/components/artist_table.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/_id/components/artist_table.rs
@@ -4,17 +4,22 @@ use crate::routes::Route;
 use bdk::prelude::by_components::icons::arrows;
 use bdk::prelude::{by_components::icons::validations, *};
 #[component]
-pub fn ArtistTable(assets: Vec<Assets> ,lang: Language, agit_id: ReadOnlySignal<i64>, artist_id:i64) -> Element {
+pub fn ArtistTable(
+    assets: Vec<Assets>,
+    lang: Language,
+    agit_id: ReadOnlySignal<i64>,
+    artist_id: i64,
+) -> Element {
     let mut active_dropdown = use_signal(|| None::<usize>);
 
-  let tr: ArtistTranslate= translate(&lang);
+    let tr: ArtistTranslate = translate(&lang);
 
     rsx! {
         table {
             class: "w-full text-sm text-left border-collapse min-w-[800px]",
             thead {
                 tr {
-    
+
                     th {class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
                       div { class: "flex items-center",
                          span {{tr.title}}
@@ -69,14 +74,14 @@ pub fn ArtistTable(assets: Vec<Assets> ,lang: Language, agit_id: ReadOnlySignal<
                           arrows::UpDown { class: "[&>path]:stroke-white [&>circle]:stroke-white", height:18, width:18 }
                        }
                     }
-               
+
                    th { class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
                     div { class: "flex items-center",
                         span { "" }
                         validations::Extra { class: "[&>circle]:stroke-white", height:18 }
                     }
                 }
-    
+
                 }
             }
             tbody {
@@ -87,12 +92,13 @@ pub fn ArtistTable(assets: Vec<Assets> ,lang: Language, agit_id: ReadOnlySignal<
                             key: "owned-tr-{index}",
                             class: "border-b border-gray-800 hover:bg-gray-900",
                             onclick: move |_| {
-                             
-                                use_navigator().push(Route::EditArtistPage { 
-                                    lang: lang, 
-                                    agit_id: agit_id(), 
+
+                                use_navigator().push(Route::EditArtistPage {
+                                    lang: lang,
+                                    agit_id: agit_id(),
                                     artist_id: artist_id
                                 });
+                                
                             },
                             td {
                                 class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
@@ -125,10 +131,10 @@ pub fn ArtistTable(assets: Vec<Assets> ,lang: Language, agit_id: ReadOnlySignal<
                             }
                             td {
                                 class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
-                              
+
                                                 {asset.medium.clone()}
-                                        
-                                  
+
+
                             }
                             td {
                                 class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
@@ -176,7 +182,7 @@ pub fn ArtistTable(assets: Vec<Assets> ,lang: Language, agit_id: ReadOnlySignal<
                                     }
                                 }
                             }
-              
+
                             td {
                                 class: "px-2 py-2 sm:px-4 sm:py-3 whitespace-nowrap",
                                 div {
@@ -202,7 +208,7 @@ pub fn ArtistTable(assets: Vec<Assets> ,lang: Language, agit_id: ReadOnlySignal<
                                         },
                                         validations::Extra { class: "[&>circle]:stroke-white", height: 18 }
                                     }
-                                  
+
                                         div {
                                             class: "absolute right-0 mt-2 w-48 bg-black border border-green-500 rounded shadow-lg z-10 hidden aria-dropdown-open:block",
                                             "aria-dropdown-open": is_dropdown_open,
@@ -234,7 +240,7 @@ pub fn ArtistTable(assets: Vec<Assets> ,lang: Language, agit_id: ReadOnlySignal<
                                                 }
                                             }
                                         }
-                                    
+
                                 }
                             }
                         }

--- a/packages/build-ui/src/pages/agits/_id/management/artists/_id/components/input_field.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/_id/components/input_field.rs
@@ -1,0 +1,19 @@
+use bdk::prelude::*;
+#[component]
+pub fn InputField(label:String, placeholder:String, onInput: EventHandler<Event<FormData>>, value: String )->Element{
+   rsx!{ 
+    div { class: "flex items-center",
+                    label { class: "text-sm w-40",
+                        span { class: "text-red-500 mr-1", "*" }
+                        {label}
+                    }
+                    input {
+                        class: "bg-border-background border border-border-primary text-white p-2.5 flex-1",
+                        placeholder: placeholder,
+                        r#type: "text",
+                        value:  value,
+                        oninput: move |e: Event<FormData>| onInput.call(e),
+                    }
+                }
+}
+}

--- a/packages/build-ui/src/pages/agits/_id/management/artists/_id/components/mod.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/_id/components/mod.rs
@@ -3,5 +3,5 @@ mod input_field;
 mod remove_popup;
 
 pub use artist_table::ArtistTable;
-pub use remove_popup::RemoveArtistModal;
+pub use remove_popup::{ConfirmRemoveArtistModal, RemoveArtistModal, SuccessModal};
 pub use input_field::InputField;

--- a/packages/build-ui/src/pages/agits/_id/management/artists/_id/components/mod.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/_id/components/mod.rs
@@ -1,3 +1,5 @@
 mod artist_table;
+mod remove_popup;
 
 pub use artist_table::ArtistTable;
+pub use remove_popup::RemoveArtistModal;

--- a/packages/build-ui/src/pages/agits/_id/management/artists/_id/components/mod.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/_id/components/mod.rs
@@ -1,3 +1,5 @@
 mod artist_table;
+mod input_field;
 
 pub use artist_table::ArtistTable;
+pub use input_field::InputField;

--- a/packages/build-ui/src/pages/agits/_id/management/artists/_id/components/remove_popup.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/_id/components/remove_popup.rs
@@ -1,0 +1,70 @@
+use bdk::prelude::*;
+
+#[component]
+pub fn RemoveArtistModal(
+    show: bool,
+    on_back: EventHandler<()>,
+    on_remove: EventHandler<()>,
+) -> Element {
+    let mut receive_announcements = use_signal(|| false);
+
+    if !show {
+        return rsx!(div {});
+    }
+
+    rsx! {
+       div {
+        class: "fixed inset-0 bg-opacity-50 backdrop-blur-sm z-50",
+        onclick: move |_| on_back.call(()),
+        // Modal content
+        div {
+            class: "fixed inset-0 flex items-center justify-center p-4",
+            div { class: "flex items-center justify-between px-6 pt-6  pb-2 border-border-primary",
+            h2 { class: "text-xl font-semibold text-white", "Transfer Artwork" }
+            button {
+                class: "text-gray-400 hover:text-white",
+                onclick: move |_| on_back.call(()),
+                svg {
+                    class: "w-6 h-6",
+                    view_box: "0 0 24 24",
+                    stroke: "currentColor",
+                    stroke_width: "2",
+                    fill: "none",
+                    path { d: "M6 18L18 6M6 6l12 12" }
+                }
+            }
+        }
+
+           
+
+           div { class:"px-6 pr-10",
+            p { class: "text-white",
+                "Removing an artist is irreversible. Once removed, all artworks associated with the artist will be converted to `Pending Sale ` status and will no longer be available for sale from that point forward."
+            } 
+            p {  
+                class: "text-white pt-4",
+                "Are you sure you want to remove this artist?"
+            }
+            div {
+                class: "flex items-center mb-4",
+                input {
+                    id: "announcements",
+                    class: "mr-2 h-4 w-4 border border-btn-signin checked:bg-white checked:border-black checked:text-black text-sm",
+                    type: "checkbox",
+                    checked: "{receive_announcements}",
+                    oninput: move |evt| receive_announcements.set(evt.value().parse().unwrap_or(false)),
+                }
+                label {
+                    class: "text-sm text-popup-label",
+                   "I acknowledge and accept the permanent removal of the artist and the legal consequences of this action, including the loss of associated rights, royalties, and future sales opportunities. I understand that this action is final and cannot be undone.",
+                }
+            }
+           }
+           
+
+        }
+        }
+    }
+}
+
+

--- a/packages/build-ui/src/pages/agits/_id/management/artists/_id/components/remove_popup.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/_id/components/remove_popup.rs
@@ -1,70 +1,236 @@
 use bdk::prelude::*;
 
+use crate::pages::agits::_id::management::artists::i18n::ArtistTranslate;
+
+#[component]
+pub fn ConfirmRemoveArtistModal(
+    show: bool,
+    on_back: EventHandler<()>,
+    on_remove: EventHandler<()>,
+    lang: Language,
+) -> Element {
+    let mut terms_accepted = use_signal(|| false);
+    let tr: ArtistTranslate = translate(&lang);
+    if !show {
+        return rsx!(div {});
+    }
+
+    rsx! {
+               // Modal backdrop with purple glow effect
+               div {
+                class: "fixed inset-0 bg-opacity-50 backdrop-blur-sm z-50",
+
+                onclick: move |_| on_back.call(()),
+                // Modal content
+                div {
+                    class: "fixed inset-0 flex items-center justify-center p-4",
+                    onclick: move |e| e.stop_propagation(),
+                    div { class: "bg-black border border-border-primary rounded-lg  w-full max-w-[550px] shadow-[0_0_40px_10px_rgba(255,41,144,0.5)]",
+                        // Modal header
+                        div { class: "flex items-center justify-between px-6 pt-6  pb-2 border-border-primary",
+                            h2 { class: "text-xl font-semibold text-white", {tr.remove_popup_title} }
+                            button {
+                                class: "text-gray-400 hover:text-white",
+                                onclick: move |_| on_back.call(()),
+                                svg {
+                                    class: "w-6 h-6",
+                                    view_box: "0 0 24 24",
+                                    stroke: "currentColor",
+                                    stroke_width: "2",
+                                    fill: "none",
+                                    path { d: "M6 18L18 6M6 6l12 12" }
+                                }
+                            }
+                        }
+                        div { class: "px-6 pr-10 py-6",
+                            p { class: "text-white",
+                                {tr.remove_popup_description_1}
+                            }
+                            p { class: "text-white pt-1",
+                                {tr.remove_popup_description_2}
+                            }
+
+                        }
+                        div { class: "p-6 pt-0 flex items-start",
+                        input {
+                            id: "announcements",
+                            class: "mr-2  h-4 w-4 border border-btn-signin checked:bg-white checked:border-black checked:text-black text-sm",
+                            type: "checkbox",
+                            checked: "{terms_accepted}",
+                            oninput: move |evt| terms_accepted.set(evt.value().parse().unwrap_or(false)),
+                        }
+                            label { class: "text-sm text-popup-label mb-2",
+                                {tr.remove_popup_confirm_text}
+                            }
+                        }
+
+                        // Modal footer
+                        div { class: "flex items-center justify-between gap-4 p-6 border-border-primary",
+                            button {
+                                class: "px-10 py-2 text-l text-popup-text hover:text-white border border-white",
+                                onclick: move |_| on_back.call(()),
+                               { tr.cancel_btn}
+                            }
+                            button {
+                                class: "px-10 py-3 text-l bg-white  text-black hover:bg-gray-200",
+                                onclick: move |_| {
+                                   on_remove.call(());
+                                },
+                               {tr.confirm_btn}
+
+                            }
+                        }
+                    }
+                }
+            }
+    }
+}
+
 #[component]
 pub fn RemoveArtistModal(
     show: bool,
     on_back: EventHandler<()>,
     on_remove: EventHandler<()>,
+    lang: Language,
 ) -> Element {
-    let mut receive_announcements = use_signal(|| false);
+    let mut collection_name = use_signal(|| String::new());
+    let tr: ArtistTranslate = translate(&lang);
+    let mut terms_accepted = use_signal(|| false);
 
     if !show {
         return rsx!(div {});
     }
 
     rsx! {
-       div {
-        class: "fixed inset-0 bg-opacity-50 backdrop-blur-sm z-50",
-        onclick: move |_| on_back.call(()),
-        // Modal content
+
         div {
-            class: "fixed inset-0 flex items-center justify-center p-4",
-            div { class: "flex items-center justify-between px-6 pt-6  pb-2 border-border-primary",
-            h2 { class: "text-xl font-semibold text-white", "Transfer Artwork" }
-            button {
-                class: "text-gray-400 hover:text-white",
-                onclick: move |_| on_back.call(()),
-                svg {
-                    class: "w-6 h-6",
-                    view_box: "0 0 24 24",
-                    stroke: "currentColor",
-                    stroke_width: "2",
-                    fill: "none",
-                    path { d: "M6 18L18 6M6 6l12 12" }
-                }
-            }
-        }
+            class: "fixed inset-0 bg-opacity-50 backdrop-blur-sm z-50",
 
-           
-
-           div { class:"px-6 pr-10",
-            p { class: "text-white",
-                "Removing an artist is irreversible. Once removed, all artworks associated with the artist will be converted to `Pending Sale ` status and will no longer be available for sale from that point forward."
-            } 
-            p {  
-                class: "text-white pt-4",
-                "Are you sure you want to remove this artist?"
-            }
+            onclick: move |_| on_back.call(()),
+            // Modal content
             div {
-                class: "flex items-center mb-4",
-                input {
-                    id: "announcements",
-                    class: "mr-2 h-4 w-4 border border-btn-signin checked:bg-white checked:border-black checked:text-black text-sm",
-                    type: "checkbox",
-                    checked: "{receive_announcements}",
-                    oninput: move |evt| receive_announcements.set(evt.value().parse().unwrap_or(false)),
-                }
-                label {
-                    class: "text-sm text-popup-label",
-                   "I acknowledge and accept the permanent removal of the artist and the legal consequences of this action, including the loss of associated rights, royalties, and future sales opportunities. I understand that this action is final and cannot be undone.",
+                class: "fixed inset-0 flex items-center justify-center p-4",
+                onclick: move |e| e.stop_propagation(),
+                div { class: "bg-popup-bg border border-border-primary rounded-lg  w-full max-w-md shadow-[0_0_40px_10px_rgba(255,41,144,0.5)]",
+                    // Modal header
+                    div { class: "flex items-center justify-between px-6 pt-6 pb-5 border-border-bg",
+                        h2 { class: "text-xl font-semibold text-white",
+                            {tr.remove_popup_2}
+                        }
+                        button {
+                            class: "text-gray-400 hover:text-white",
+                            onclick: move |_| on_back.call(()),
+                            svg {
+                                class: "w-6 h-6",
+                                view_box: "0 0 24 24",
+                                stroke: "currentColor",
+                                stroke_width: "2",
+                                fill: "none",
+                                path { d: "M6 18L18 6M6 6l12 12" }
+                            }
+                        }
+                    }
+                    // Modal body
+                    div { class: "px-6 pb-5",
+                        p { class: "text-sm text-white mb-4", {tr.remove_popup_2_description} }
+                        // Collection name input
+                        div { class: "mb-4",
+                            input {
+                                class: "w-full bg-transparent border border-[1px] text-white text-sm rounded-none p-2 focus:outline-none focus:border-primary",
+                                    placeholder: "Artist name",
+                                value: "{collection_name}",
+                                oninput: move |evt| collection_name.set(evt.value().clone()),
+                            }
+                        }
+                        // Short URL input
+                        div { class: "flex items-start",
+                        input {
+                            id: "announcements",
+                            class: "mr-2  h-4 w-4 border border-btn-signin checked:bg-white checked:border-black checked:text-black text-sm",
+                            type: "checkbox",
+                            checked: "{terms_accepted}",
+                            oninput: move |evt| terms_accepted.set(evt.value().parse().unwrap_or(false)),
+                        }
+                            label { class: "text-sm text-popup-label mb-2",
+                                {tr.remove_popup_confirm_text_2}
+                            }
+                        }
+                    }
+
+
+                      // Modal footer
+                      div { class: "flex items-center justify-between gap-4 p-6 pt-0 border-border-primary",
+                      button {
+                          class: "px-10 py-2 text-l text-popup-text hover:text-white border border-white",
+                          onclick: move |_| on_back.call(()),
+                         { tr.cancel_btn}
+                      }
+                      button {
+                          class: "px-10 py-3 text-l bg-white  text-black hover:bg-gray-200",
+                          onclick: move |_| {
+                             on_remove.call(());
+                          },
+                         {tr.confirm_btn}
+
+                      }
+                  }
                 }
             }
-           }
-           
-
-        }
         }
     }
 }
 
+#[component]
+pub fn SuccessModal(
+    show: bool,
+    on_back: EventHandler<()>,
+    on_confirm: EventHandler<()>,
+    lang: Language,
+) -> Element {
+    let tr: ArtistTranslate = translate(&lang);
+    if !show {
+        return rsx!(div {});
+    }
 
+    rsx! {
+        // Modal backdrop
+        div {
+            class: "fixed inset-0 bg-opacity-50 backdrop-blur-sm z-50",
+            // Modal content
+            div { class: "fixed inset-0 flex items-center justify-center p-4",
+                div { class: "bg-filter-bg border border-border-primary rounded-lg  w-full max-w-md text-center shadow-[0_0_40px_10px_rgba(255,41,144,0.5)]",
+                          // Modal header
+                          div { class: "flex items-center justify-between px-6 pt-6  pb-2 border-border-primary",
+                          h2 { class: "text-xl font-semibold text-white", {tr.remove_popup_title} }
+                          button {
+                              class: "text-gray-400 hover:text-white",
+                              onclick: move |_| on_back.call(()),
+                              svg {
+                                  class: "w-6 h-6",
+                                  view_box: "0 0 24 24",
+                                  stroke: "currentColor",
+                                  stroke_width: "2",
+                                  fill: "none",
+                                  path { d: "M6 18L18 6M6 6l12 12" }
+                              }
+                          }
+                      }
+                    // Modal body
+                    div { class: "px-6 py-2",
+                        p { class: "text-white",
+                            {tr.success_popup_description}
+                        }
+                    }
+                    // Modal footer
+                    div { class: "flex items-center p-6 border-border-primary",
+                        button {
+                            class: "flex-1 px-6 py-2 bg-white text-sm text-black hover:bg-gray-200 min-w[120px]",
+                            onclick: move |_| on_confirm.call(()),
+                            {tr.confirm_btn}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/build-ui/src/pages/agits/_id/management/artists/_id/mod.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/_id/mod.rs
@@ -2,4 +2,5 @@ mod page;
 mod components;
 
 pub use page::{ArtistDetailPage, EditArtistPage};
-pub use components::{RemoveArtistModal,InputField};
+pub use components::InputField;
+pub use components::RemoveArtistModal;

--- a/packages/build-ui/src/pages/agits/_id/management/artists/_id/mod.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/_id/mod.rs
@@ -2,3 +2,4 @@ mod page;
 mod components;
 
 pub use page::{ArtistDetailPage, EditArtistPage};
+pub use components::RemoveArtistModal;

--- a/packages/build-ui/src/pages/agits/_id/management/artists/_id/mod.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/_id/mod.rs
@@ -2,5 +2,5 @@ mod page;
 mod components;
 
 pub use page::{ArtistDetailPage, EditArtistPage};
-pub use components::InputField;
-pub use components::RemoveArtistModal;
+
+pub use components::{InputField, RemoveArtistModal, ConfirmRemoveArtistModal,SuccessModal};

--- a/packages/build-ui/src/pages/agits/_id/management/artists/_id/mod.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/_id/mod.rs
@@ -2,3 +2,4 @@ mod page;
 mod components;
 
 pub use page::{ArtistDetailPage, EditArtistPage};
+pub use components::InputField;

--- a/packages/build-ui/src/pages/agits/_id/management/artists/_id/mod.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/_id/mod.rs
@@ -1,4 +1,4 @@
 mod page;
 mod components;
 
-pub use page::ArtistDetailPage;
+pub use page::{ArtistDetailPage, EditArtistPage};

--- a/packages/build-ui/src/pages/agits/_id/management/artists/_id/page.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/_id/page.rs
@@ -1,7 +1,9 @@
-use bdk::prelude::by_components::icons::{arrows, edit, layouts, settings, validations, other_devices};
+use bdk::prelude::by_components::icons::{
+    arrows, edit, layouts, other_devices, settings, validations,
+};
 use bdk::prelude::*;
 
-use crate::pages::agits::_id::management::artists::_id::components::ArtistTable;
+use crate::pages::agits::_id::management::artists::_id::components::{ArtistTable, InputField};
 use crate::pages::agits::_id::management::artists::controllers::Controller;
 use crate::pages::agits::_id::management::artists::i18n::ArtistTranslate;
 use crate::pages::agits::_id::management::components::NftTable;
@@ -150,15 +152,19 @@ pub fn ArtistDetailPage(lang: Language, agit_id: ReadOnlySignal<i64>, artist_id:
 }
 
 #[component]
-pub fn EditArtistPage(lang: Language, agit_id: ReadOnlySignal<i64>, artist_id: i64) -> Element {
-    let _tr: ArtistTranslate = translate(&lang);
+pub fn EditArtistPage(
+    lang: Language,
+    agit_id: ReadOnlySignal<i64>,
+    artist_id: ReadOnlySignal<i64>,
+) -> Element {
+    let tr: ArtistTranslate = translate(&lang);
     let mut ctrl = Controller::new(lang, agit_id)?;
     let _profile_picture = use_signal(|| None::<String>);
-    let mut is_dropdown_open = use_signal(||false);
+    let mut is_dropdown_open = use_signal(|| false);
 
     // Handle form submission
     let handle_save = move |_| {
-       // todo: similate api this
+        // todo: similate api this
     };
 
     rsx! {
@@ -167,7 +173,7 @@ pub fn EditArtistPage(lang: Language, agit_id: ReadOnlySignal<i64>, artist_id: i
                 // Header with title and back button
                 div { class: "flex items-center mb-6",
                     Link {
-                        to: Route::ArtistDetailPage { lang, agit_id: agit_id(), artist_id },
+                        to: Route::ArtistDetailPage { lang, agit_id: agit_id(), artist_id: artist_id() },
                         class: "text-gray-400 hover:text-white mr-4",
                         svg {
                             xmlns: "http://www.w3.org/2000/svg",
@@ -185,37 +191,40 @@ pub fn EditArtistPage(lang: Language, agit_id: ReadOnlySignal<i64>, artist_id: i
                      }
                     div {  class: "flex justify-between w-full",
                     h1 { class: "text-2xl font-bold", "Edit {artist_id}'s Info" }
-                  
+
                     div { class: "relative",
                     button{
                         onclick: move |_| {
-                            let is_open = *is_dropdown_open.read();
-                            is_dropdown_open.set(!is_open);
+                            is_dropdown_open.toggle();
                         },
                     settings::Settings2 { class: "ml-2 [&>path]:stroke-white", height: 20, width: 20}
                     }
                         div { class: "absolute right-0 mt-2 w-48 bg-background border border-border-primary rounded-md shadow-lg z-1 hidden aria-dropdown-open:block",
                              "aria-dropdown-open": is_dropdown_open,
                             div { class: "py-1",
-                                Link {
-                                    to: Route::ArtistDetailPage { lang, agit_id: agit_id(), artist_id },
-                                    class: "block px-4 py-2 text-sm text-white hover:bg-gray-700 hover:text-white",
-                                    "Artist Detail"
-                                }
-                                a { class: "block px-4 py-2 text-sm text-white hover:bg-gray-700 hover:text-white",
-                                    "Edit Artist Info"
-                                }
-                                a { class: "block px-4 py-2 text-sm text-white hover:bg-gray-700 hover:text-white",
-                                    "Delete Artist"
-                                }
+                            Link{
+                                to:Route::ArtistPage { lang, agit_id: agit_id() },
+                                class: "block px-4 py-2 text-sm text-white hover:bg-gray-700 hover:text-white",
+                                "Artist Detail"
+                            }
+                            Link {
+                                to:Route::ArtistPage { lang, agit_id: agit_id() },
+                                 class: "block px-4 py-2 text-sm text-white hover:bg-gray-700 hover:text-white",
+                                "Edit Artist Info"
+                            }
+                            Link {
+                                to:Route::ArtistPage { lang, agit_id: agit_id() },
+                                class: "block px-4 py-2 text-sm text-white hover:bg-gray-700 hover:text-white",
+                                "Delete Artist"
+                            }
                             }
                         }
-                    
+
                 }
-                            
-                    
-                        
-                    
+
+
+
+
                     }
                 }
 
@@ -232,77 +241,43 @@ pub fn EditArtistPage(lang: Language, agit_id: ReadOnlySignal<i64>, artist_id: i
 
             // Form fields
             div { class: "space-y-4 max-w-4xl",
-                div { class: "flex items-center",
-                    label { class: "text-sm w-40",
-                        span { class: "text-red-500 mr-1", "*" }
-                        "Display Name or Email"
-                    }
-                    input {
-                        class: "bg-border-background border border-border-primary text-white p-2.5 flex-1",
-                        placeholder: "Input",
-                        r#type: "text",
-                        value:"{ctrl.artist_input_field().display_name.clone()}",
-                        oninput: move |evt| ctrl.update_artist_field("display_name".to_string(), evt.value().clone())
-                    }
-                }
 
-                div { class: "flex items-center",
-                    label { class: "text-sm w-40", "Social Media" }
-                    input {
-                        class: "bg-border-background border border-border-primary text-white p-2.5 flex-1",
-                        placeholder: "Input",
-                        r#type: "text",
-                        value:"{ctrl.artist_input_field().social_media.clone()}",
-                        oninput: move |evt| ctrl.update_artist_field("social_media".to_string(), evt.value().clone())
-                    }
-                }
+               InputField{
+                label: tr.input_artist_name,
+                placeholder: tr.input_artist_name_placeholder,
+                value: ctrl.artist_input_field().display_name.clone(),
+                onInput: move |evt: Event<FormData>| ctrl.update_artist_field("display_name".to_string(), evt.value().clone())
+               }
 
-                div { class: "flex items-center",
-                    label { class: "text-sm w-40",
-                        span { class: "text-red-500 mr-1", "*" }
-                        "Medium"
-                    }
-                    input {
-                        class: "bg-border-background border border-border-primary text-white p-2.5 flex-1",
-                        placeholder: "Input",
-                        r#type: "text",
-                        value:"{ctrl.artist_input_field().medium.clone()}",
-                        oninput: move |evt| ctrl.update_artist_field("medium".to_string(), evt.value().clone())
-                    }
-                }
+      InputField{
+                label: tr.social_media_label,
+                placeholder: tr.social_media_label,
+                value: ctrl.artist_input_field().social_media.clone(),
+                onInput: move |evt: Event<FormData>| ctrl.update_artist_field("social_media".to_string(), evt.value().clone())
+               }
 
-                div { class: "flex items-center",
-                    label { class: "text-sm w-40",
-                        span { class: "text-red-500 mr-1", "*" }
-                        "Theme"
-                    }
-                    input {
-                        class: "bg-border-background border border-border-primary text-white p-2.5 flex-1",
-                        placeholder: "Input",
-                        r#type: "text",
-                        value:"{ctrl.artist_input_field().theme.clone()}",
-                        oninput: move |evt| ctrl.update_artist_field("theme".to_string(), evt.value().clone())
-                  
-                    }
-                }
+               InputField{
+                label: tr.medium,
+                placeholder: tr.medium,
+                value: ctrl.artist_input_field().medium.clone(),
+                onInput: move |evt: Event<FormData>| ctrl.update_artist_field("medium".to_string(), evt.value().clone())
+               }
 
-                div { class: "flex items-center",
-                    label { class: "text-sm w-40",
-                        span { class: "text-red-500 mr-1", "*" }
-                        "Art Style"
-                    }
-                    input {
-                        class: "bg-border-background border border-border-primary text-white p-2.5 flex-1",
-                        placeholder: "Input",
-                        r#type: "text",
-                        value:"{ctrl.artist_input_field().art_style.clone()}",
-                        oninput: move |evt| ctrl.update_artist_field("art_style".to_string(), evt.value().clone())
-                    }
-                }
+               InputField{
+                label: tr.theme,
+                placeholder: tr.theme,
+                value: ctrl.artist_input_field().theme.clone(),
+                onInput: move |evt: Event<FormData>| ctrl.update_artist_field("theme".to_string(), evt.value().clone())
+               }
+
+               InputField{
+                label: tr.art_style,
+                placeholder: tr.art_style,
+                value: ctrl.artist_input_field().art_style.clone(),
+                onInput: move |evt: Event<FormData>| ctrl.update_artist_field("art_style".to_string(), evt.value().clone())
+               }
             }
-
-
-                        // Profile Picture Upload
+                         // Profile Picture Upload
                         div { class: "flex flex-col mt-8",
                             label { class: "mb-1 text-sm", "Profile Picture" }
                             div {
@@ -323,17 +298,17 @@ pub fn EditArtistPage(lang: Language, agit_id: ReadOnlySignal<i64>, artist_id: i
                                     }
                                 }
                                 p { class: "text-sm text-gray-400",
-                                    "Please drag and drop your file here."
+                                    {tr.upload_img_label_1}
                                 }
                                 p { class: "text-xs text-gray-500",
-                                    "One or more files (JPG, PNG)"
+                                    {tr.upload_img_label_2}
                                 }
                             }
                             p { class: "text-xs text-gray-500 mt-1",
-                                "Maximum resolution: 3000px × 3000px (square format)"
+                                {tr.max_file_size}
                             }
                             p { class: "text-xs text-gray-500",
-                                "Uploads are allowed under 10MB"
+                                {tr.max_file_size_2}
                             }
                         }
                 }
@@ -341,15 +316,15 @@ pub fn EditArtistPage(lang: Language, agit_id: ReadOnlySignal<i64>, artist_id: i
                 // Introduction Section
                 div { class: "mb-8 mt-8 max-w-4xl",
                     div { class: "flex items-center mb-4",
-                        h2 { class: "text-xl font-semibold", "Introduction" }
+                        h2 { class: "text-xl font-semibold", {tr.introduction_label} }
                         arrows::ChevronDown { class: "ml-2 [&>path]:stroke-white", height: 20, width: 20 }
                     }
 
                     textarea {
                         class: "bg-border-background border border-border-primary text-white p-4 w-full h-32",
-                        placeholder: "Please feel free to describe your artistic work, style, and creative philosophy. It would be wonderful if you could share the message behind your art and the unique aspects of your work.",
+                        placeholder: tr.introduction_placeholder,
                         value: "{ctrl.artist_input_field().introduction.clone()}",
-                      
+
                         oninput: move |evt| {
                             ctrl.update_artist_field("introduction".to_string(), evt.value().clone())
                         }
@@ -360,13 +335,13 @@ pub fn EditArtistPage(lang: Language, agit_id: ReadOnlySignal<i64>, artist_id: i
                 // Biography Section
                 div { class: "mt-8 max-w-4xl",
                     div { class: "flex items-center mb-4",
-                        h2 { class: "text-xl font-semibold", "Biography" }
+                        h2 { class: "text-xl font-semibold", {tr.biography_label} }
                         arrows::ChevronDown { class: "ml-2 [&>path]:stroke-white", height: 20, width: 20 }
                     }
 
                     textarea {
                         class: "bg-border-background border border-border-primary text-white p-4 w-full h-32",
-                        placeholder: "Please provide a brief introduction about yourself, including your background, career, and areas of expertise. Sharing who you are and what experiences have shaped you would be greatly appreciated.",
+                        placeholder: tr.biography_placeholder,
                         value: "{ctrl.artist_input_field().biography.clone()}",
                         oninput: move |evt| {
                             ctrl.update_artist_field("biography".to_string(), evt.value().clone())

--- a/packages/build-ui/src/pages/agits/_id/management/artists/_id/page.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/_id/page.rs
@@ -150,7 +150,7 @@ pub fn ArtistDetailPage(lang: Language, agit_id: ReadOnlySignal<i64>, artist_id:
 }
 
 #[component]
-pub fn EditArtistPage(lang: Language, agit_id: ReadOnlySignal<i64>, artist_id: i64) -> Element {
+pub fn EditArtistPage(lang: Language, agit_id: ReadOnlySignal<i64>, artist_id: ReadOnlySignal<i64>) -> Element {
     let _tr: ArtistTranslate = translate(&lang);
     let mut ctrl = Controller::new(lang, agit_id)?;
     let _profile_picture = use_signal(|| None::<String>);
@@ -167,7 +167,7 @@ pub fn EditArtistPage(lang: Language, agit_id: ReadOnlySignal<i64>, artist_id: i
                 // Header with title and back button
                 div { class: "flex items-center mb-6",
                     Link {
-                        to: Route::ArtistDetailPage { lang, agit_id: agit_id(), artist_id },
+                        to: Route::ArtistDetailPage { lang, agit_id: agit_id(),artist_id: artist_id()},
                         class: "text-gray-400 hover:text-white mr-4",
                         svg {
                             xmlns: "http://www.w3.org/2000/svg",
@@ -197,10 +197,12 @@ pub fn EditArtistPage(lang: Language, agit_id: ReadOnlySignal<i64>, artist_id: i
                         div { class: "absolute right-0 mt-2 w-48 bg-background border border-border-primary rounded-md shadow-lg z-1 hidden aria-dropdown-open:block",
                              "aria-dropdown-open": is_dropdown_open,
                             div { class: "py-1",
-                                Link {
-                                    to: Route::ArtistDetailPage { lang, agit_id: agit_id(), artist_id },
+                                a {
                                     class: "block px-4 py-2 text-sm text-white hover:bg-gray-700 hover:text-white",
-                                    "Artist Detail"
+                                    onclick: move |_| {
+                                      ctrl.remove_artist_popup();  
+                                    },
+                                    "Remove Artist"
                                 }
                                 a { class: "block px-4 py-2 text-sm text-white hover:bg-gray-700 hover:text-white",
                                     "Edit Artist Info"

--- a/packages/build-ui/src/pages/agits/_id/management/artists/_id/page.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/_id/page.rs
@@ -1,4 +1,4 @@
-use bdk::prelude::by_components::icons::{arrows, edit, layouts, settings, validations};
+use bdk::prelude::by_components::icons::{arrows, edit, layouts, settings, validations, other_devices};
 use bdk::prelude::*;
 
 use crate::pages::agits::_id::management::artists::_id::components::ArtistTable;
@@ -136,7 +136,7 @@ pub fn ArtistDetailPage(lang: Language, agit_id: ReadOnlySignal<i64>, artist_id:
                             }
                         }else{
                         rsx!{
-                            ArtistTable {assets: artist_assets.clone(), lang}
+                            ArtistTable {assets: artist_assets.clone(), lang, agit_id: agit_id(), artist_id}
                         }
                             }
                         }
@@ -149,3 +149,241 @@ pub fn ArtistDetailPage(lang: Language, agit_id: ReadOnlySignal<i64>, artist_id:
     }
 }
 
+#[component]
+pub fn EditArtistPage(lang: Language, agit_id: ReadOnlySignal<i64>, artist_id: i64) -> Element {
+    let _tr: ArtistTranslate = translate(&lang);
+    let mut ctrl = Controller::new(lang, agit_id)?;
+    let _profile_picture = use_signal(|| None::<String>);
+    let mut is_dropdown_open = use_signal(||false);
+
+    // Handle form submission
+    let handle_save = move |_| {
+       // todo: similate api this
+    };
+
+    rsx! {
+        div { class: "w-full min-h-screen bg-background h-full flex text-white items-center",
+            div { class: "flex flex-col w-full h-full p-6",
+                // Header with title and back button
+                div { class: "flex items-center mb-6",
+                    Link {
+                        to: Route::ArtistDetailPage { lang, agit_id: agit_id(), artist_id },
+                        class: "text-gray-400 hover:text-white mr-4",
+                        svg {
+                            xmlns: "http://www.w3.org/2000/svg",
+                            class: "h-6 w-6",
+                            fill: "none",
+                            view_box: "0 0 24 24",
+                            stroke: "currentColor",
+                            path {
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                stroke_width: "2",
+                                d: "M15 19l-7-7 7-7"
+                            }
+                        }
+                     }
+                    div {  class: "flex justify-between w-full",
+                    h1 { class: "text-2xl font-bold", "Edit {artist_id}'s Info" }
+                  
+                    div { class: "relative",
+                    button{
+                        onclick: move |_| {
+                            let is_open = *is_dropdown_open.read();
+                            is_dropdown_open.set(!is_open);
+                        },
+                    settings::Settings2 { class: "ml-2 [&>path]:stroke-white", height: 20, width: 20}
+                    }
+                        div { class: "absolute right-0 mt-2 w-48 bg-background border border-border-primary rounded-md shadow-lg z-1 hidden aria-dropdown-open:block",
+                             "aria-dropdown-open": is_dropdown_open,
+                            div { class: "py-1",
+                                Link {
+                                    to: Route::ArtistDetailPage { lang, agit_id: agit_id(), artist_id },
+                                    class: "block px-4 py-2 text-sm text-white hover:bg-gray-700 hover:text-white",
+                                    "Artist Detail"
+                                }
+                                a { class: "block px-4 py-2 text-sm text-white hover:bg-gray-700 hover:text-white",
+                                    "Edit Artist Info"
+                                }
+                                a { class: "block px-4 py-2 text-sm text-white hover:bg-gray-700 hover:text-white",
+                                    "Delete Artist"
+                                }
+                            }
+                        }
+                    
+                }
+                            
+                    
+                        
+                    
+                    }
+                }
+
+                p { class: "text-gray-400 mb-8",
+                    "Joined Feb 20, 2025"
+                }
+
+                // Artist Info Section
+                div { class: "mb-8",
+                div { class: "flex items-center mb-4",
+                h2 { class: "text-xl font-semibold", "Artist Info" }
+                arrows::ChevronDown { class: "ml-2 [&>path]:stroke-white", height: 20, width: 20 }
+            }
+
+            // Form fields
+            div { class: "space-y-4 max-w-4xl",
+                div { class: "flex items-center",
+                    label { class: "text-sm w-40",
+                        span { class: "text-red-500 mr-1", "*" }
+                        "Display Name or Email"
+                    }
+                    input {
+                        class: "bg-border-background border border-border-primary text-white p-2.5 flex-1",
+                        placeholder: "Input",
+                        r#type: "text",
+                        value:"{ctrl.artist_input_field().display_name.clone()}",
+                        oninput: move |evt| ctrl.update_artist_field("display_name".to_string(), evt.value().clone())
+                    }
+                }
+
+                div { class: "flex items-center",
+                    label { class: "text-sm w-40", "Social Media" }
+                    input {
+                        class: "bg-border-background border border-border-primary text-white p-2.5 flex-1",
+                        placeholder: "Input",
+                        r#type: "text",
+                        value:"{ctrl.artist_input_field().social_media.clone()}",
+                        oninput: move |evt| ctrl.update_artist_field("social_media".to_string(), evt.value().clone())
+                    }
+                }
+
+                div { class: "flex items-center",
+                    label { class: "text-sm w-40",
+                        span { class: "text-red-500 mr-1", "*" }
+                        "Medium"
+                    }
+                    input {
+                        class: "bg-border-background border border-border-primary text-white p-2.5 flex-1",
+                        placeholder: "Input",
+                        r#type: "text",
+                        value:"{ctrl.artist_input_field().medium.clone()}",
+                        oninput: move |evt| ctrl.update_artist_field("medium".to_string(), evt.value().clone())
+                    }
+                }
+
+                div { class: "flex items-center",
+                    label { class: "text-sm w-40",
+                        span { class: "text-red-500 mr-1", "*" }
+                        "Theme"
+                    }
+                    input {
+                        class: "bg-border-background border border-border-primary text-white p-2.5 flex-1",
+                        placeholder: "Input",
+                        r#type: "text",
+                        value:"{ctrl.artist_input_field().theme.clone()}",
+                        oninput: move |evt| ctrl.update_artist_field("theme".to_string(), evt.value().clone())
+                  
+                    }
+                }
+
+                div { class: "flex items-center",
+                    label { class: "text-sm w-40",
+                        span { class: "text-red-500 mr-1", "*" }
+                        "Art Style"
+                    }
+                    input {
+                        class: "bg-border-background border border-border-primary text-white p-2.5 flex-1",
+                        placeholder: "Input",
+                        r#type: "text",
+                        value:"{ctrl.artist_input_field().art_style.clone()}",
+                        oninput: move |evt| ctrl.update_artist_field("art_style".to_string(), evt.value().clone())
+                    }
+                }
+            }
+
+
+                        // Profile Picture Upload
+                        div { class: "flex flex-col mt-8",
+                            label { class: "mb-1 text-sm", "Profile Picture" }
+                            div {
+                                class: "border border-dashed border-green-500 flex flex-col items-center justify-center text-center text-center w-[340px] h-[340px]",
+
+                                // You would implement file upload functionality here
+                                svg {
+                                    xmlns: "http://www.w3.org/2000/svg",
+                                    class: "h-12 w-12 text-gray-400 mb-2",
+                                    fill: "none",
+                                    view_box: "0 0 24 24",
+                                    stroke: "currentColor",
+                                    path {
+                                        stroke_linecap: "round",
+                                        stroke_linejoin: "round",
+                                        stroke_width: "1",
+                                        d: "M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                                    }
+                                }
+                                p { class: "text-sm text-gray-400",
+                                    "Please drag and drop your file here."
+                                }
+                                p { class: "text-xs text-gray-500",
+                                    "One or more files (JPG, PNG)"
+                                }
+                            }
+                            p { class: "text-xs text-gray-500 mt-1",
+                                "Maximum resolution: 3000px × 3000px (square format)"
+                            }
+                            p { class: "text-xs text-gray-500",
+                                "Uploads are allowed under 10MB"
+                            }
+                        }
+                }
+
+                // Introduction Section
+                div { class: "mb-8 mt-8 max-w-4xl",
+                    div { class: "flex items-center mb-4",
+                        h2 { class: "text-xl font-semibold", "Introduction" }
+                        arrows::ChevronDown { class: "ml-2 [&>path]:stroke-white", height: 20, width: 20 }
+                    }
+
+                    textarea {
+                        class: "bg-border-background border border-border-primary text-white p-4 w-full h-32",
+                        placeholder: "Please feel free to describe your artistic work, style, and creative philosophy. It would be wonderful if you could share the message behind your art and the unique aspects of your work.",
+                        value: "{ctrl.artist_input_field().introduction.clone()}",
+                      
+                        oninput: move |evt| {
+                            ctrl.update_artist_field("introduction".to_string(), evt.value().clone())
+                        }
+
+                    }
+                }
+
+                // Biography Section
+                div { class: "mt-8 max-w-4xl",
+                    div { class: "flex items-center mb-4",
+                        h2 { class: "text-xl font-semibold", "Biography" }
+                        arrows::ChevronDown { class: "ml-2 [&>path]:stroke-white", height: 20, width: 20 }
+                    }
+
+                    textarea {
+                        class: "bg-border-background border border-border-primary text-white p-4 w-full h-32",
+                        placeholder: "Please provide a brief introduction about yourself, including your background, career, and areas of expertise. Sharing who you are and what experiences have shaped you would be greatly appreciated.",
+                        value: "{ctrl.artist_input_field().biography.clone()}",
+                        oninput: move |evt| {
+                            ctrl.update_artist_field("biography".to_string(), evt.value().clone())
+                        }
+                    }
+                }
+
+                // Action buttons
+                div { class: "flex justify-end space-x-4 mt-8",
+                    button {
+                        class: "border border-white text-white px-6 py-2 flex items-center justify-center",
+                        onclick: handle_save,
+                        other_devices::Save { class: "mr-2 [&>path]:stroke-white", height: 20, width: 20 }
+                        "Save"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/build-ui/src/pages/agits/_id/management/artists/_id/page.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/_id/page.rs
@@ -202,10 +202,13 @@ pub fn EditArtistPage(
                         div { class: "absolute right-0 mt-2 w-48 bg-background border border-border-primary rounded-md shadow-lg z-1 hidden aria-dropdown-open:block",
                              "aria-dropdown-open": is_dropdown_open,
                             div { class: "py-1",
-                            Link{
-                                to:Route::ArtistPage { lang, agit_id: agit_id() },
+                            a{
+                                // to:Route::ArtistPage { lang, agit_id: agit_id() },
+                                onclick: move|_|{
+                                    ctrl.remove_artist_popup();
+                                },
                                 class: "block px-4 py-2 text-sm text-white hover:bg-gray-700 hover:text-white",
-                                "Artist Detail"
+                                "Remove Artist"
                             }
                             Link {
                                 to:Route::ArtistPage { lang, agit_id: agit_id() },

--- a/packages/build-ui/src/pages/agits/_id/management/artists/controllers.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/controllers.rs
@@ -6,10 +6,17 @@ use common::tables::{
 };
 use wasm_bindgen_futures::spawn_local;
 
-use bdk::prelude::*;
+use bdk::prelude::{dioxus_popup::PopupService, *};
 
-use crate::{config::Config, pages::agits::_id::management::Assets, routes::Route};
+use crate::{config::Config, pages::agits::_id::management::{artists::RemoveArtistModal, Assets}, routes::Route};
+#[derive(Debug, Clone, PartialEq)]
+enum ModalState{
+    None,
+    ConfirmRemoval,
+    ConfirmNameRemoval,
+    Success,
 
+}
 #[derive(Debug, Clone, Copy, DioxusController)]
 pub struct Controller {
     lang: Language,
@@ -17,9 +24,13 @@ pub struct Controller {
     artist: Signal<Vec<Artist>>,
     artist_input_field: Signal<ArtistInputField>,
     artist_asset: Signal<Vec<Assets>>,
+    modal_state:Signal<ModalState>,
+    popup:PopupService
+
 }
 impl Controller {
     pub fn new(lang: Language, agit_id: ReadOnlySignal<i64>) -> Result<Self, RenderError> {
+        let mut popup:PopupService = use_context();
         let res = use_server_future(move || async move {
             let endpoint = crate::config::get().api_url;
             let client = ArtistModel::get_client(endpoint);
@@ -86,12 +97,16 @@ impl Controller {
               rarity: "Rare".to_string(),
           }).collect::<Vec<_>>()
         });
+        let modal_state = use_signal(|| ModalState::None);
+
         let ctrl = Self {
             lang,
             agit_id,
             artist,
             artist_input_field,
             artist_asset,
+            modal_state,
+            popup 
         };
         use_context_provider(|| ctrl);
         Ok(ctrl)
@@ -192,4 +207,65 @@ pub fn update_artist_field(&mut self, field: String, value: String) {
             agit_id: self.agit_id.with(|id  | *id),
         });
     }
+
+
+fn update_modal_state(&mut self, state:ModalState){
+    self.modal_state.set(state.clone());
+    self.popup.close();
+
+    match state {
+        ModalState::None=>{},
+        ModalState::ConfirmRemoval=>{
+            let mut this = self.clone();
+            self.popup.open(
+                rsx!(
+                    RemoveArtistModal{show:true,
+                    on_back: move |_| this.update_modal_state(ModalState::None),
+                    on_remove: move |_| {
+                        // self.remove_artist(self.agit_id.with(|id| *id));
+                        this.update_modal_state(ModalState::ConfirmNameRemoval);
+                    },
+                }
+                )
+            ).with_id("remove-artist-modal");
+        },
+        ModalState::ConfirmNameRemoval=>{
+            let mut this = self.clone();
+            self.popup.open(
+                rsx!(
+                    RemoveArtistModal{
+                    show:true,
+                    on_back: move |_| this.update_modal_state(ModalState::None),
+                    on_remove: move |_| {
+                        this.remove_artist(this.agit_id.with(|id| *id));
+                        this.update_modal_state(ModalState::Success);
+                    },
+                }
+                )
+            ).with_id("remove-artistName-modal");
+
+        },
+        ModalState::Success=>{
+            let mut this = self.clone();
+            self.popup.open(
+                rsx!(
+                    RemoveArtistModal{show:true,
+                    on_back: move |_| this.update_modal_state(ModalState::None),
+                    on_remove: move |_| {
+                        this.update_modal_state(ModalState::None);
+                    },
+                }
+                )
+            ).with_id("remove-artist-modal-success");
+        }
+    }
+
+}
+
+
+
+
+pub fn remove_artist_popup(&mut self){
+    self.update_modal_state(ModalState::ConfirmRemoval);
+}
 }

--- a/packages/build-ui/src/pages/agits/_id/management/artists/controllers.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/controllers.rs
@@ -8,7 +8,7 @@ use wasm_bindgen_futures::spawn_local;
 
 use bdk::prelude::{dioxus_popup::PopupService, *};
 
-use crate::{config::Config, pages::agits::_id::management::{artists::RemoveArtistModal, Assets}, routes::Route};
+use crate::{config::Config, pages::agits::_id::management::{artists::{ConfirmRemoveArtistModal, RemoveArtistModal, SuccessModal}, Assets}, routes::Route};
 #[derive(Debug, Clone, PartialEq)]
 enum ModalState{
     None,
@@ -217,20 +217,23 @@ fn update_modal_state(&mut self, state:ModalState){
         ModalState::None=>{},
         ModalState::ConfirmRemoval=>{
             let mut this = self.clone();
+            let lang = self.lang;
             self.popup.open(
                 rsx!(
-                    RemoveArtistModal{show:true,
+                    ConfirmRemoveArtistModal{show:true,
                     on_back: move |_| this.update_modal_state(ModalState::None),
                     on_remove: move |_| {
                         // self.remove_artist(self.agit_id.with(|id| *id));
                         this.update_modal_state(ModalState::ConfirmNameRemoval);
                     },
+                    lang: lang
                 }
                 )
             ).with_id("remove-artist-modal");
         },
         ModalState::ConfirmNameRemoval=>{
             let mut this = self.clone();
+            let lang = self.lang;
             self.popup.open(
                 rsx!(
                     RemoveArtistModal{
@@ -240,6 +243,7 @@ fn update_modal_state(&mut self, state:ModalState){
                         this.remove_artist(this.agit_id.with(|id| *id));
                         this.update_modal_state(ModalState::Success);
                     },
+                    lang: lang
                 }
                 )
             ).with_id("remove-artistName-modal");
@@ -247,13 +251,14 @@ fn update_modal_state(&mut self, state:ModalState){
         },
         ModalState::Success=>{
             let mut this = self.clone();
+            let lang = self.lang;
             self.popup.open(
                 rsx!(
-                    RemoveArtistModal{show:true,
+                    SuccessModal{
+                    show:true,
                     on_back: move |_| this.update_modal_state(ModalState::None),
-                    on_remove: move |_| {
-                        this.update_modal_state(ModalState::None);
-                    },
+                    on_confirm: move |_| this.update_modal_state(ModalState::None),
+                    lang: lang
                 }
                 )
             ).with_id("remove-artist-modal-success");

--- a/packages/build-ui/src/pages/agits/_id/management/artists/i18n.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/i18n.rs
@@ -82,6 +82,61 @@ translate! {
         en: "Title",
         ko: "제목",
     }
-
+    social_media_label:{
+        en: "Social Media",
+        ko: "소셜 미디어",
+    }
+    input_artist_name:{
+        en: "Display Name or Email",
+        ko: "표시 이름 또는 이메일",
+    }
+    input_artist_name_placeholder:{
+        en: "Display Name or Email",
+        ko: "표시 이름 또는 이메일",
+    }
+  theme:{
+      en: "Theme",
+      ko: "테마",
+  }
+  art_style:{
+      en: "Art Style",
+      ko: "아트 스타일",
+  }
+  upload_img_label_1:{
+        en: "Please drag and drop your file here.",
+        ko: "여기에 파일을 드래그 앤 드롭하세요.",
+  }
+  upload_img_label_2:{
+        en: "One or more files (JPG, PNG)",
+        ko: "하나 이상의 파일 (JPG, PNG)",
+  }
+  max_file_size:{
+        en: "Maximum resolution: 3000px × 3000px (square format)",
+        ko: "최대 해상도: 3000px × 3000px (사각형 형식)",
+  }
+  max_file_size_2:{
+        en: "Uploads are allowed under 10MB",
+        ko: "업로드는 10MB 미만이어야 합니다.",
+  }
+ introduction_placeholder:{
+        en: "Please feel free to describe your artistic work, style, and creative philosophy. It would be wonderful if you could share the message behind your art and the unique aspects of your work.",
+        ko: "예술 작품, 스타일 및 창작 철학에 대해 자유롭게 설명해 주십시오. 예술 뒤에 숨겨진 메시지와 작업의 독특한 측면을 공유할 수 있다면 좋겠습니다.",
+  }
+  introduction_label:{
+        en: "Introduction",
+        ko: "소개",
+  }
+    biography_label:{
+            en: "Biography",
+            ko: "약력",
+    }
+    biography_placeholder:{
+        en:"Please provide a brief introduction about yourself, including your background, career, and areas of expertise. Sharing who you are and what experiences have shaped you would be greatly appreciated.",
+        ko: " "
+    }
+    new_artist_description:{
+        en:"Register a new artist on the platform. Showcase their work, share exhibition history, and connect with curators and galleries.",
+        ko: " "
+    }
     
 }

--- a/packages/build-ui/src/pages/agits/_id/management/artists/i18n.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/i18n.rs
@@ -138,5 +138,50 @@ translate! {
         en:"Register a new artist on the platform. Showcase their work, share exhibition history, and connect with curators and galleries.",
         ko: " "
     }
+    remove_popup_title:{
+        en: "Artist Removal Confirmation",
+        ko: "작가 제거 확인",
+    }
+    remove_popup_description_1:{
+        en: "Removing an artist is irreversible. Once removed, all artworks associated with the artist will be converted to `Pending Sale` status and will no longer be available for sale from that point forward.",
+        ko: "작가를 제거하는 것은 되돌릴 수 없습니다. 제거되면 해당 작가와 관련된 모든 작품은 '판매 보류' 상태로 전환되며 그 시점부터 판매할 수 없습니다.",
+    }
+    remove_popup_description_2:{
+        en: "Are you sure you want to remove the artist?",
+        ko: "위 정보를 읽고 이해했음을 확인해 주십시오.",
+    }
+    remove_popup_confirm_text:{
+        en:"I acknowledge and accept the permanent removal of the artist and the legal consequences of this action, including the loss of associated rights, royalties, and future sales opportunities. I understand that this action is final and cannot be undone.",
+        ko:"작가의 영구 제거와 이 조치의 법적 결과, 즉 관련 권리, 로열티 및 향후 판매 기회의 상실을 인정하고 수용합니다. 이 조치는 최종적이며 되돌릴 수 없음을 이해합니다.",
+    }
+    confirm_btn:{
+        en: "Confirm",
+        ko: "확인",
+    }
+    cancel_btn:{
+        en: "Cancel",
+        ko: "취소",
+    }
+    remove_popup_2:{
+        en:"Remove the Artist from your agit",
+        ko: "작가를 아짓에서 제거",
+
+    }
+    remove_popup_2_description:{
+        en: "Please note that removed artists cannot be restored.\nEnter the name of the artist you want to delete."
+        ko: "제거된 작가는 복원할 수 없습니다. 삭제하려는 작가의 이름을 입력하세요.",
+    }
+    remove_popup_confirm_text_2:{
+        en:"I have read and accept the Terms of Service.",
+        ko:"서비스 약관을 읽고 동의합니다.",
+    }
+    success_popup_title:{
+        en: "Removed Artist",
+        ko: "작가 제거됨",
+    }
+    success_popup_description:{
+        en: "The artist has been removed from your agit. Returning to the previous screen.",
+        ko: "작가가 아짓에서 제거되었습니다. 이전 화면으로 돌아갑니다.",
+    }
     
 }

--- a/packages/build-ui/src/pages/agits/_id/management/artists/mod.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/mod.rs
@@ -6,5 +6,5 @@ mod new;
 mod models;
 
 pub use page::ArtistPage;
-pub use _id::{ArtistDetailPage, EditArtistPage, RemoveArtistModal};
+pub use _id::{ArtistDetailPage, EditArtistPage, ConfirmRemoveArtistModal, RemoveArtistModal, SuccessModal};
 pub use new::NewArtistPage;

--- a/packages/build-ui/src/pages/agits/_id/management/artists/mod.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/mod.rs
@@ -6,5 +6,5 @@ mod new;
 mod models;
 
 pub use page::ArtistPage;
-pub use _id::ArtistDetailPage;
+pub use _id::{ArtistDetailPage, EditArtistPage};
 pub use new::NewArtistPage;

--- a/packages/build-ui/src/pages/agits/_id/management/artists/mod.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/mod.rs
@@ -6,5 +6,5 @@ mod new;
 mod models;
 
 pub use page::ArtistPage;
-pub use _id::{ArtistDetailPage, EditArtistPage};
+pub use _id::{ArtistDetailPage, EditArtistPage, RemoveArtistModal};
 pub use new::NewArtistPage;

--- a/packages/build-ui/src/pages/agits/_id/management/artists/new/page.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/new/page.rs
@@ -1,4 +1,4 @@
-use bdk::prelude::{by_components::icons::{arrows, validations}, *};
+use bdk::prelude::{by_components::icons::{arrows, other_devices, validations}, *};
 
 use crate::{pages::agits::_id::management::artists::{controllers::Controller, i18n::ArtistTranslate}, routes::Route};
 #[component]
@@ -198,6 +198,7 @@ pub fn NewArtistPage(lang: Language, agit_id: ReadOnlySignal<i64>) -> Element {
                     button {
                         class: "border border-white text-white px-6 py-2 flex items-center justify-center",
                         onclick: handle_save,
+                        other_devices::Save { class: "mr-2 [&>path]:stroke-white", height: 20, width: 20 }
                         "Save"
                     }
 

--- a/packages/build-ui/src/pages/agits/_id/management/artists/new/page.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/new/page.rs
@@ -22,7 +22,7 @@ pub fn NewArtistPage(lang: Language, agit_id: ReadOnlySignal<i64>) -> Element {
                         class: "text-gray-400 hover:text-white mr-4",
                         svg {
                             xmlns: "http://www.w3.org/2000/svg",
-                            class: "h-6 w-6",
+                              class: "h-6 w-6",
                             fill: "none",
                             view_box: "0 0 24 24",
                             stroke: "currentColor",

--- a/packages/build-ui/src/pages/agits/_id/management/artists/new/page.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/new/page.rs
@@ -4,12 +4,14 @@ use bdk::prelude::{
 };
 
 use crate::{
-    pages::agits::_id::management::artists::{controllers::Controller, i18n::ArtistTranslate},
+    pages::agits::_id::management::artists::{
+        _id::InputField, controllers::Controller, i18n::ArtistTranslate,
+    },
     routes::Route,
 };
 #[component]
 pub fn NewArtistPage(lang: Language, agit_id: ReadOnlySignal<i64>) -> Element {
-    let _tr: ArtistTranslate = translate(&lang);
+    let tr: ArtistTranslate = translate(&lang);
     let mut ctrl = Controller::new(lang, agit_id)?;
     let _profile_picture = use_signal(|| None::<String>);
     let mut is_dropdown_open = use_signal(|| false);
@@ -19,237 +21,205 @@ pub fn NewArtistPage(lang: Language, agit_id: ReadOnlySignal<i64>) -> Element {
     };
 
     rsx! {
-        div { class: "w-full min-h-screen bg-background h-full flex text-white items-center",
-            div { class: "flex flex-col w-full h-full  p-6",
-                // Header with title and back button
-                div { class: "flex items-center mb-6",
-                    Link {
-                        to: Route::ArtistPage { lang, agit_id: agit_id() },
-                        class: "text-gray-400 hover:text-white mr-4",
-                        svg {
-                            xmlns: "http://www.w3.org/2000/svg",
-                            class: "h-6 w-6",
-                            fill: "none",
-                            view_box: "0 0 24 24",
-                            stroke: "currentColor",
-                            path {
-                                stroke_linecap: "round",
-                                stroke_linejoin: "round",
-                                stroke_width: "2",
-                                d: "M15 19l-7-7 7-7"
-                            }
-                        }
-                    }
+          div { class: "w-full min-h-screen bg-background h-full flex text-white items-center",
+              div { class: "flex flex-col w-full h-full  p-6",
+                  // Header with title and back button
+                  div { class: "flex items-center mb-6",
+                      Link {
+                          to: Route::ArtistPage { lang, agit_id: agit_id() },
+                          class: "text-gray-400 hover:text-white mr-4",
+                          svg {
+                              xmlns: "http://www.w3.org/2000/svg",
+                              class: "h-6 w-6",
+                              fill: "none",
+                              view_box: "0 0 24 24",
+                              stroke: "currentColor",
+                              path {
+                                  stroke_linecap: "round",
+                                  stroke_linejoin: "round",
+                                  stroke_width: "2",
+                                  d: "M15 19l-7-7 7-7"
+                              }
+                          }
+                      }
 
-                    div {  class: "flex justify-between w-full",
-                    h1 { class: "text-2xl font-bold", "Add Artist" }
+                      div {  class: "flex justify-between w-full",
+                      h1 { class: "text-2xl font-bold", "Add Artist" }
 
-                    div { class: "relative",
-                    button{
-                        onclick: move |_| {
-                            let is_open = *is_dropdown_open.read();
-                            is_dropdown_open.set(!is_open);
-                        },
-                    settings::Settings2 { class: "ml-2 [&>path]:stroke-white", height: 20, width: 20}
-                    }
-                        div { class: "absolute right-0 mt-2 w-48 bg-background border border-border-primary rounded-md shadow-lg z-1 hidden aria-dropdown-open:block",
-                             "aria-dropdown-open": is_dropdown_open,
-                            div { class: "py-1",
-                                a {
-                                    class: "block px-4 py-2 text-sm text-white hover:bg-gray-700 hover:text-white",
-                                    "Artist Detail"
-                                }
-                                a { class: "block px-4 py-2 text-sm text-white hover:bg-gray-700 hover:text-white",
-                                    "Edit Artist Info"
-                                }
-                                a { class: "block px-4 py-2 text-sm text-white hover:bg-gray-700 hover:text-white",
-                                    "Delete Artist"
-                                }
-                            }
-                        }
+                      div { class: "relative",
+                      button{
+                          onclick: move |_| {
+                              is_dropdown_open.toggle();
+                          },
+                      settings::Settings2 { class: "ml-2 [&>path]:stroke-white", height: 20, width: 20}
+                      }
+                          div { class: "absolute right-0 mt-2 w-48 bg-background border border-border-primary rounded-md shadow-lg z-1 hidden aria-dropdown-open:block",
+                               "aria-dropdown-open": is_dropdown_open,
+                              div { class: "py-1",
+                                  Link{
+                                      to:Route::ArtistPage { lang, agit_id: agit_id() },
+                                      class: "block px-4 py-2 text-sm text-white hover:bg-gray-700 hover:text-white",
+                                      "Artist Detail"
+                                  }
+                                  Link {
+                                      to:Route::ArtistPage { lang, agit_id: agit_id() },
+                                       class: "block px-4 py-2 text-sm text-white hover:bg-gray-700 hover:text-white",
+                                      "Edit Artist Info"
+                                  }
+                                  Link {
+                                      to:Route::ArtistPage { lang, agit_id: agit_id() },
+                                      class: "block px-4 py-2 text-sm text-white hover:bg-gray-700 hover:text-white",
+                                      "Delete Artist"
+                                  }
+                              }
+                          }
 
-                }
+                  }
 
 
 
 
-                    }
-                }
+                      }
+                  }
 
-                p { class: "text-gray-400 mb-8",
-                    "Register a new artist on the platform. Showcase their work, share exhibition history, and connect with curators and galleries."
-                }
+                  p { class: "text-gray-400 mb-8",
+                      {tr.new_artist_description}
+                  }
 
-                // Artist Info Section
-                div { class: "mb-8",
-                div { class: "flex items-center mb-4",
-                h2 { class: "text-xl font-semibold", "Artist Info" }
-                arrows::ChevronDown { class: "ml-2 [&>path]:stroke-white", height: 20, width: 20 }
-            }
+                  // Artist Info Section
+                  div { class: "mb-8",
+                  div { class: "flex items-center mb-4",
+                  h2 { class: "text-xl font-semibold", "Artist Info" }
+                  arrows::ChevronDown { class: "ml-2 [&>path]:stroke-white", height: 20, width: 20 }
+              }
 
-            // Form fields
-            div { class: "space-y-4 max-w-4xl",
-                div { class: "flex items-center",
-                    label { class: "text-sm w-40",
-                        span { class: "text-red-500 mr-1", "*" }
-                        "Display Name or Email"
-                    }
-                    input {
-                        class: "bg-border-background border border-border-primary text-white p-2.5 flex-1",
-                        placeholder: "Input",
-                        r#type: "text",
-                        value:"{ctrl.artist_input_field().display_name.clone()}",
-                        oninput: move |evt| ctrl.update_artist_field("display_name".to_string(), evt.value().clone())
-                    }
-                }
+              // Form fields
+              div { class: "space-y-4 max-w-4xl",
+              InputField{
+                  label: tr.input_artist_name,
+                  placeholder: tr.input_artist_name_placeholder,
+                  value: ctrl.artist_input_field().display_name.clone(),
+                  onInput: move |evt: Event<FormData>| ctrl.update_artist_field("display_name".to_string(), evt.value().clone())
+                 }
 
-                div { class: "flex items-center",
-                    label { class: "text-sm w-40", "Social Media" }
-                    input {
-                        class: "bg-border-background border border-border-primary text-white p-2.5 flex-1",
-                        placeholder: "Input",
-                        r#type: "text",
-                        value:"{ctrl.artist_input_field().social_media.clone()}",
-                        oninput: move |evt| ctrl.update_artist_field("social_media".to_string(), evt.value().clone())
-                    }
-                }
+                 InputField{
+                  label: tr.social_media_label,
+                  placeholder: tr.social_media_label,
+                  value: ctrl.artist_input_field().social_media.clone(),
+                  onInput: move |evt: Event<FormData>| ctrl.update_artist_field("social_media".to_string(), evt.value().clone())
+                 }
 
-                div { class: "flex items-center",
-                    label { class: "text-sm w-40",
-                        span { class: "text-red-500 mr-1", "*" }
-                        "Medium"
-                    }
-                    input {
-                        class: "bg-border-background border border-border-primary text-white p-2.5 flex-1",
-                        placeholder: "Input",
-                        r#type: "text",
-                        value:"{ctrl.artist_input_field().medium.clone()}",
-                        oninput: move |evt| ctrl.update_artist_field("medium".to_string(), evt.value().clone())
-                    }
-                }
+                 InputField{
+                  label: tr.medium,
+                  placeholder: tr.medium,
+                  value: ctrl.artist_input_field().medium.clone(),
+                  onInput: move |evt: Event<FormData>| ctrl.update_artist_field("medium".to_string(), evt.value().clone())
+                 }
+                 InputField{
+                  label: tr.theme,
+                  placeholder: tr.theme,
+                  value: ctrl.artist_input_field().theme.clone(),
+                  onInput: move |evt: Event<FormData>| ctrl.update_artist_field("theme".to_string(), evt.value().clone())
+                 }
 
-                div { class: "flex items-center",
-                    label { class: "text-sm w-40",
-                        span { class: "text-red-500 mr-1", "*" }
-                        "Theme"
-                    }
-                    input {
-                        class: "bg-border-background border border-border-primary text-white p-2.5 flex-1",
-                        placeholder: "Input",
-                        r#type: "text",
-                        value:"{ctrl.artist_input_field().theme.clone()}",
-                        oninput: move |evt| ctrl.update_artist_field("theme".to_string(), evt.value().clone())
+                 InputField{
+                  label: tr.art_style,
+                  placeholder: tr.art_style,
+                  value: ctrl.artist_input_field().art_style.clone(),
+                  onInput: move |evt: Event<FormData>| ctrl.update_artist_field("art_style".to_string(), evt.value().clone())
+                 }
+              }
 
-                    }
-                }
+        // Profile Picture Upload
+        div { class: "flex flex-col mt-8",
+        label { class: "mb-1 text-sm", "Profile Picture" }
+        div {
+            class: "border border-dashed border-green-500 flex flex-col items-center justify-center text-center text-center w-[340px] h-[340px]",
 
-                div { class: "flex items-center",
-                    label { class: "text-sm w-40",
-                        span { class: "text-red-500 mr-1", "*" }
-                        "Art Style"
-                    }
-                    input {
-                        class: "bg-border-background border border-border-primary text-white p-2.5 flex-1",
-                        placeholder: "Input",
-                        r#type: "text",
-                        value:"{ctrl.artist_input_field().art_style.clone()}",
-                        oninput: move |evt| ctrl.update_artist_field("art_style".to_string(), evt.value().clone())
-                    }
+            // You would implement file upload functionality here
+            svg {
+                xmlns: "http://www.w3.org/2000/svg",
+                class: "h-12 w-12 text-gray-400 mb-2",
+                fill: "none",
+                view_box: "0 0 24 24",
+                stroke: "currentColor",
+                path {
+                    stroke_linecap: "round",
+                    stroke_linejoin: "round",
+                    stroke_width: "1",
+                    d: "M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
                 }
             }
-
-
-                        // Profile Picture Upload
-                        div { class: "flex flex-col mt-8",
-                            label { class: "mb-1 text-sm", "Profile Picture" }
-                            div {
-                                class: "border border-dashed border-green-500 flex flex-col items-center justify-center text-center text-center w-[340px] h-[340px]",
-
-                                // You would implement file upload functionality here
-                                svg {
-                                    xmlns: "http://www.w3.org/2000/svg",
-                                    class: "h-12 w-12 text-gray-400 mb-2",
-                                    fill: "none",
-                                    view_box: "0 0 24 24",
-                                    stroke: "currentColor",
-                                    path {
-                                        stroke_linecap: "round",
-                                        stroke_linejoin: "round",
-                                        stroke_width: "1",
-                                        d: "M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
-                                    }
-                                }
-                                p { class: "text-sm text-gray-400",
-                                    "Please drag and drop your file here."
-                                }
-                                p { class: "text-xs text-gray-500",
-                                    "One or more files (JPG, PNG)"
-                                }
-                            }
-                            p { class: "text-xs text-gray-500 mt-1",
-                                "Maximum resolution: 3000px × 3000px (square format)"
-                            }
-                            p { class: "text-xs text-gray-500",
-                                "Uploads are allowed under 10MB"
-                            }
-                        }
-                }
-
-                // Introduction Section
-                div { class: "mb-8 mt-8 max-w-4xl",
-                    div { class: "flex items-center mb-4",
-                        h2 { class: "text-xl font-semibold", "Introduction" }
-                        arrows::ChevronDown { class: "ml-2 [&>path]:stroke-white", height: 20, width: 20 }
-                    }
-
-                    textarea {
-                        class: "bg-border-background border border-border-primary text-white p-4 w-full h-32",
-                        placeholder: "Please feel free to describe your artistic work, style, and creative philosophy. It would be wonderful if you could share the message behind your art and the unique aspects of your work.",
-                        value: "{ctrl.artist_input_field().introduction.clone()}",
-
-                        oninput: move |evt| {
-                            ctrl.update_artist_field("introduction".to_string(), evt.value().clone())
-                        }
-
-                    }
-                }
-
-                // Biography Section
-                div { class: "mt-8 max-w-4xl",
-                    div { class: "flex items-center mb-4",
-                        h2 { class: "text-xl font-semibold", "Biography" }
-                        arrows::ChevronDown { class: "ml-2 [&>path]:stroke-white", height: 20, width: 20 }
-                    }
-
-                    textarea {
-                        class: "bg-border-background border border-border-primary text-white p-4 w-full h-32",
-                        placeholder: "Please provide a brief introduction about yourself, including your background, career, and areas of expertise. Sharing who you are and what experiences have shaped you would be greatly appreciated.",
-                        value: "{ctrl.artist_input_field().biography.clone()}",
-                        oninput: move |evt| {
-                            ctrl.update_artist_field("biography".to_string(), evt.value().clone())
-                        }
-                    }
-                }
-
-                // Action buttons
-                div { class: "flex justify-end space-x-4 mt-8",
-                    button {
-                        class: "border border-white text-white px-6 py-2 flex items-center justify-center",
-                        onclick: handle_save,
-                        other_devices::Save { class: "mr-2 [&>path]:stroke-white", height: 20, width: 20 }
-                        "Save"
-                    }
-
-                    button {
-                        class: "border border-white text-white px-6 py-2 flex items-center justify-center",
-                        onclick: move |_| {
-                                ctrl.create_artist();
-                        },
-                        validations::Add { class: "mr-2 [&>path]:stroke-white [&>circle]:stroke-white" }
-                        "Add Artwork"
-                    }
-                }
+            p { class: "text-sm text-gray-400",
+                {tr.upload_img_label_1}
+            }
+            p { class: "text-xs text-gray-500",
+                {tr.upload_img_label_2}
             }
         }
+        p { class: "text-xs text-gray-500 mt-1",
+            {tr.max_file_size}
+        }
+        p { class: "text-xs text-gray-500",
+            {tr.max_file_size_2}
+        }
     }
+                  }
+
+                  // Introduction Section
+                  div { class: "mb-8 mt-8 max-w-4xl",
+                      div { class: "flex items-center mb-4",
+                          h2 { class: "text-xl font-semibold", {tr.introduction_label} }
+                          arrows::ChevronDown { class: "ml-2 [&>path]:stroke-white", height: 20, width: 20 }
+                      }
+                      textarea {
+                          class: "bg-border-background border border-border-primary text-white p-4 w-full h-32",
+                          placeholder: tr.introduction_placeholder,
+                          value: "{ctrl.artist_input_field().introduction.clone()}",
+
+                          oninput: move |evt| {
+                              ctrl.update_artist_field("introduction".to_string(), evt.value().clone())
+                          }
+
+                      }
+                  }
+
+                  // Biography Section
+                  div { class: "mt-8 max-w-4xl",
+                      div { class: "flex items-center mb-4",
+                          h2 { class: "text-xl font-semibold", {tr.biography_label} }
+                          arrows::ChevronDown { class: "ml-2 [&>path]:stroke-white", height: 20, width: 20 }
+                      }
+
+                      textarea {
+                          class: "bg-border-background border border-border-primary text-white p-4 w-full h-32",
+                          placeholder: tr.biography_placeholder,
+                          value: "{ctrl.artist_input_field().biography.clone()}",
+                          oninput: move |evt| {
+                              ctrl.update_artist_field("biography".to_string(), evt.value().clone())
+                          }
+                      }
+                  }
+
+                  // Action buttons
+                  div { class: "flex justify-end space-x-4 mt-8",
+                      button {
+                          class: "border border-white text-white px-6 py-2 flex items-center justify-center",
+                          onclick: handle_save,
+                          other_devices::Save { class: "mr-2 [&>path]:stroke-white", height: 20, width: 20 }
+                          "Save"
+                      }
+
+                      button {
+                          class: "border border-white text-white px-6 py-2 flex items-center justify-center",
+                          onclick: move |_| {
+                                  ctrl.create_artist();
+                          },
+                          validations::Add { class: "mr-2 [&>path]:stroke-white [&>circle]:stroke-white" }
+                          "Add Artwork"
+                      }
+                  }
+              }
+          }
+      }
 }

--- a/packages/build-ui/src/pages/agits/_id/management/artists/new/page.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/new/page.rs
@@ -1,20 +1,26 @@
-use bdk::prelude::{by_components::icons::{arrows, other_devices, validations}, *};
+use bdk::prelude::{
+    by_components::icons::{arrows, other_devices, settings, validations},
+    *,
+};
 
-use crate::{pages::agits::_id::management::artists::{controllers::Controller, i18n::ArtistTranslate}, routes::Route};
+use crate::{
+    pages::agits::_id::management::artists::{controllers::Controller, i18n::ArtistTranslate},
+    routes::Route,
+};
 #[component]
 pub fn NewArtistPage(lang: Language, agit_id: ReadOnlySignal<i64>) -> Element {
     let _tr: ArtistTranslate = translate(&lang);
     let mut ctrl = Controller::new(lang, agit_id)?;
     let _profile_picture = use_signal(|| None::<String>);
-
+    let mut is_dropdown_open = use_signal(|| false);
     // Handle form submission
     let handle_save = move |_| {
-       // todo: similate api this
+        // todo: similate api this
     };
 
     rsx! {
         div { class: "w-full min-h-screen bg-background h-full flex text-white items-center",
-            div { class: "flex flex-col w-full h-full max-w-4xl p-6",
+            div { class: "flex flex-col w-full h-full  p-6",
                 // Header with title and back button
                 div { class: "flex items-center mb-6",
                     Link {
@@ -35,7 +41,39 @@ pub fn NewArtistPage(lang: Language, agit_id: ReadOnlySignal<i64>) -> Element {
                         }
                     }
 
+                    div {  class: "flex justify-between w-full",
                     h1 { class: "text-2xl font-bold", "Add Artist" }
+
+                    div { class: "relative",
+                    button{
+                        onclick: move |_| {
+                            let is_open = *is_dropdown_open.read();
+                            is_dropdown_open.set(!is_open);
+                        },
+                    settings::Settings2 { class: "ml-2 [&>path]:stroke-white", height: 20, width: 20}
+                    }
+                        div { class: "absolute right-0 mt-2 w-48 bg-background border border-border-primary rounded-md shadow-lg z-1 hidden aria-dropdown-open:block",
+                             "aria-dropdown-open": is_dropdown_open,
+                            div { class: "py-1",
+                                a {
+                                    class: "block px-4 py-2 text-sm text-white hover:bg-gray-700 hover:text-white",
+                                    "Artist Detail"
+                                }
+                                a { class: "block px-4 py-2 text-sm text-white hover:bg-gray-700 hover:text-white",
+                                    "Edit Artist Info"
+                                }
+                                a { class: "block px-4 py-2 text-sm text-white hover:bg-gray-700 hover:text-white",
+                                    "Delete Artist"
+                                }
+                            }
+                        }
+
+                }
+
+
+
+
+                    }
                 }
 
                 p { class: "text-gray-400 mb-8",
@@ -50,7 +88,7 @@ pub fn NewArtistPage(lang: Language, agit_id: ReadOnlySignal<i64>) -> Element {
             }
 
             // Form fields
-            div { class: "space-y-4",
+            div { class: "space-y-4 max-w-4xl",
                 div { class: "flex items-center",
                     label { class: "text-sm w-40",
                         span { class: "text-red-500 mr-1", "*" }
@@ -101,7 +139,7 @@ pub fn NewArtistPage(lang: Language, agit_id: ReadOnlySignal<i64>) -> Element {
                         r#type: "text",
                         value:"{ctrl.artist_input_field().theme.clone()}",
                         oninput: move |evt| ctrl.update_artist_field("theme".to_string(), evt.value().clone())
-                  
+
                     }
                 }
 
@@ -158,7 +196,7 @@ pub fn NewArtistPage(lang: Language, agit_id: ReadOnlySignal<i64>) -> Element {
                 }
 
                 // Introduction Section
-                div { class: "mb-8 mt-8",
+                div { class: "mb-8 mt-8 max-w-4xl",
                     div { class: "flex items-center mb-4",
                         h2 { class: "text-xl font-semibold", "Introduction" }
                         arrows::ChevronDown { class: "ml-2 [&>path]:stroke-white", height: 20, width: 20 }
@@ -168,7 +206,7 @@ pub fn NewArtistPage(lang: Language, agit_id: ReadOnlySignal<i64>) -> Element {
                         class: "bg-border-background border border-border-primary text-white p-4 w-full h-32",
                         placeholder: "Please feel free to describe your artistic work, style, and creative philosophy. It would be wonderful if you could share the message behind your art and the unique aspects of your work.",
                         value: "{ctrl.artist_input_field().introduction.clone()}",
-                      
+
                         oninput: move |evt| {
                             ctrl.update_artist_field("introduction".to_string(), evt.value().clone())
                         }
@@ -177,7 +215,7 @@ pub fn NewArtistPage(lang: Language, agit_id: ReadOnlySignal<i64>) -> Element {
                 }
 
                 // Biography Section
-                div { class: "mt-8",
+                div { class: "mt-8 max-w-4xl",
                     div { class: "flex items-center mb-4",
                         h2 { class: "text-xl font-semibold", "Biography" }
                         arrows::ChevronDown { class: "ml-2 [&>path]:stroke-white", height: 20, width: 20 }

--- a/packages/build-ui/src/pages/agits/_id/management/artists/page.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/artists/page.rs
@@ -151,7 +151,7 @@ pub fn ArtistPage(lang: Language, agit_id: ReadOnlySignal<i64>) -> Element {
                         
                         
                           tr { 
-                              key: "owned-{artist.id}",
+                              key: "owned-tr-{artist.id}",
                               class: "hover:bg-gray-900 cursor-pointer",
                           onclick: move |_| {
                             let artist_id = artist.id.clone();

--- a/packages/build-ui/src/pages/agits/_id/management/collections/controllers.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/collections/controllers.rs
@@ -1,10 +1,22 @@
 #![allow(unused)]
-use crate::pages::agits::_id::management::{collections::components::{
-    CollectionNameModal, NewCollectionModal, SuccessModal, TransferConfirmationModal,
-}, Activity, Assets};
-
 use super::models::*;
+use crate::config::Config;
+use crate::pages::agits::_id::management::{
+    Activity, Assets,
+    collections::components::{
+        CollectionNameModal, NewCollectionModal, SuccessModal, TransferConfirmationModal,
+    },
+};
 use bdk::prelude::{dioxus_popup::PopupService, *};
+use common::tables::{
+    artists::Artist as ArtistModel,
+    collections::Collection as CollectionModel,
+    prelude::{
+        ArtistByIdAction, ArtistCreateRequest, ArtistDeleteRequest, ArtistQuery,
+        CollectionByIdAction, CollectionCreateRequest, CollectionDeleteRequest, CollectionQuery,
+    },
+};
+use wasm_bindgen_futures::spawn_local;
 
 // Define modal states to track which modal is currently shown
 #[derive(Debug, Clone, PartialEq)]
@@ -15,6 +27,7 @@ enum ModalState {
     CollectionName,
     Success,
 }
+
 
 #[derive(Debug, Clone, Copy, DioxusController)]
 pub struct Controller {
@@ -34,6 +47,17 @@ pub struct Controller {
 impl Controller {
     pub fn new(lang: Language, agit_id: ReadOnlySignal<i64>) -> Result<Self, RenderError> {
         let mut popup: PopupService = use_context();
+        let res = use_server_future(move || async move {
+            let endpoint = crate::config::get().api_url;
+            let client = CollectionModel::get_client(endpoint);
+            client
+                .query(CollectionQuery::new(100).with_page(0))
+                .await
+                .unwrap_or_default()
+        })?;
+
+        tracing::debug!("res: {:?}", res);
+
         let collections = use_signal(|| {
             (1..15)
                 .map(|id| Collection {
@@ -71,7 +95,7 @@ impl Controller {
                 })
                 .collect::<Vec<_>>()
         });
-        let asset = use_signal(||{
+        let asset = use_signal(|| {
             (0..8).map(|id| Assets{
                 id : id.to_string(),
                 title: "Asset Title".to_string(),
@@ -95,18 +119,20 @@ impl Controller {
                 medium: "Digital".to_string(),
                 rarity: "Rare".to_string(),
             }).collect::<Vec<_>>()
-         });
-        
-         let activity = use_signal(||{
-            (0..6).map(|id|Activity{
-                id: id.to_string(),
-                from: "20114FWO".to_string(),
-                to: "20114FWO".to_string(),
-                time: "30 mins ago".to_string(),
-                title: "Art Title".to_string()
-            }).collect::<Vec<_>>()
-         });
-        
+        });
+
+        let activity = use_signal(|| {
+            (0..6)
+                .map(|id| Activity {
+                    id: id.to_string(),
+                    from: "20114FWO".to_string(),
+                    to: "20114FWO".to_string(),
+                    time: "30 mins ago".to_string(),
+                    title: "Art Title".to_string(),
+                })
+                .collect::<Vec<_>>()
+        });
+
         let selected_artworks = use_signal(|| Vec::<usize>::new());
         let modal_state = use_signal(|| ModalState::None);
         let collection_name = use_signal(|| String::new());
@@ -128,24 +154,72 @@ impl Controller {
         Ok(ctrl)
     }
 
-    
-    // Method to update the modal state and open the appropriate modal using popup_service
+    pub fn create_collection(&self) {
+        spawn_local(async move {
+            let endpoint = crate::config::get().api_url;
+            let client = CollectionModel::get_client(endpoint);
+            let res = client
+                .act(common::tables::prelude::CollectionAction::Create(
+                    CollectionCreateRequest {
+                        title: "".to_string(),
+                        description: "".to_string(),
+                        external_link: None,
+                        banner_url: "".to_string(),
+                        logo_url: "".to_string(),
+                    },
+                ))
+                .await;
+            match res {
+                Ok(_) => {
+                    tracing::debug!("Collection created successfully");
+                }
+                Err(err) => {
+                    tracing::error!("Error creating collection: {:?}", err);
+                }
+            }
+        });
+    }
 
-    fn update_modal_state(&mut self, state: ModalState) {
+    pub fn remove_collection(&self, collection_id: i64) {
+        spawn_local(async move {
+            let endpoint = crate::config::get().api_url;
+            let client = CollectionModel::get_client(endpoint);
+            let res = client
+                .act_by_id(
+                    collection_id,
+                    CollectionByIdAction::Delete(CollectionDeleteRequest {}),
+                )
+                .await;
+            match res {
+                Ok(_) => {
+                    tracing::debug!("Collection removed successfully");
+                }
+                Err(err) => {
+                    tracing::error!("Error removing collection: {:?}", err);
+                }
+            }
+        });
+    }
+
+
+
+
+
+    // Method to update the modal state and open the appropriate modal using popup_service
+ fn update_modal_state(&mut self, state: ModalState) {
         self.modal_state.set(state.clone());
         self.popup.close();
-        
-        
+
         // Open the appropriate modal based on state
         match state {
-            ModalState::None => {},
+            ModalState::None => {}
             ModalState::NewCollection => {
                 let artworks_data = self.artworks.read().clone();
                 let mut selected_artworks = self.selected_artworks.clone();
                 let mut this = self.clone();
-                
-                self.popup.open(rsx!(
-                    NewCollectionModal {
+
+                self.popup
+                    .open(rsx!(NewCollectionModal {
                         show: true,
                         on_close: move |_| this.update_modal_state(ModalState::None),
                         artworks: artworks_data,
@@ -153,66 +227,63 @@ impl Controller {
                             selected_artworks.set(selected.clone());
                             this.update_modal_state(ModalState::TransferConfirmation);
                         },
-                    }
-                )).with_id("new-collection-modal");
-            },
+                    }))
+                    .with_id("new-collection-modal");
+            }
 
             ModalState::TransferConfirmation => {
                 let selected_count = self.selected_artworks.read().len();
                 let mut this = self.clone();
-                
-                self.popup.open(rsx!(
-                    TransferConfirmationModal {
+
+                self.popup
+                    .open(rsx!(TransferConfirmationModal {
                         show: true,
                         selected_count,
                         on_back: move |_| this.update_modal_state(ModalState::NewCollection),
                         on_continue: move |_| this.update_modal_state(ModalState::CollectionName),
-                    }
-                )).with_id("transfer-confirmation-modal");
-            },
-
+                    }))
+                    .with_id("transfer-confirmation-modal");
+            }
 
             ModalState::CollectionName => {
                 let mut this = self.clone();
                 let mut collection_name = self.collection_name.clone();
-                
-                self.popup.open(rsx!(
-                    CollectionNameModal {
+
+                self.popup
+                    .open(rsx!(CollectionNameModal {
                         show: true,
                         on_back: move |_| this.update_modal_state(ModalState::TransferConfirmation),
                         on_add: move |name: String| {
                             collection_name.set(name.clone());
                             tracing::debug!("Collection Name: {}", name);
-                        //    todo:: function to simulate the api to addcollection will be called here before the success modal
+                            //    todo:: function to simulate the api to addcollection will be called here before the success modal
                             this.update_modal_state(ModalState::Success);
                         },
-                    }
-                )).with_id("collection-name-modal");
-            },
-
+                    }))
+                    .with_id("collection-name-modal");
+            }
 
             ModalState::Success => {
                 let collection_name = self.collection_name.read().clone();
                 let mut this = self.clone();
-                
-                self.popup.open(rsx!(
-                    SuccessModal {
+
+                self.popup
+                    .open(rsx!(SuccessModal {
                         show: true,
                         collection_name,
                         on_confirm: move |_| {
                             // Reset state and close modal
-                           
+
                             this.update_modal_state(ModalState::None);
                         },
-                    }
-                )).with_id("success-modal");
-            },
+                    }))
+                    .with_id("success-modal");
+            }
         }
     }
 
-
     // Public method to start the modal flow
     pub fn open_new_collection_popup(&mut self) {
-            self.update_modal_state(ModalState::NewCollection);
-        }
+        self.update_modal_state(ModalState::NewCollection);
+    }
 }

--- a/packages/build-ui/src/pages/agits/_id/management/collectors/controllers.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/collectors/controllers.rs
@@ -1,45 +1,58 @@
 #![allow(unused)]
 use std::io::Read;
 
-use bdk::prelude::{dioxus_popup::PopupService, *};
-
-use crate::pages::agits::_id::management::{Activity, Assets};
-
-use super::models::{Collector};
 use super::models::*;
+use crate::pages::agits::_id::management::{Activity, Assets};
+use bdk::prelude::{dioxus_popup::PopupService, *};
+use wasm_bindgen_futures::spawn_local;
+use common::tables::{
+    collectors::Collector as CollectorModel,
+    prelude::{CollectorByIdAction, CollectorCreateRequest, CollectorDeleteRequest, CollectorQuery},
+};
+
+
 
 
 #[derive(Debug, Clone, Copy, DioxusController)]
-pub struct Controller{
+pub struct Controller {
     lang: Language,
     collector: Signal<Vec<Collector>>,
     asset: Signal<Vec<Assets>>,
     activity: Signal<Vec<Activity>>,
-    popup: PopupService
-
- 
+    popup: PopupService,
 }
-impl Controller{
-  pub fn new(lang: Language, agit_id: ReadOnlySignal<i64>)-> Result<Self, RenderError>{
-    let mut popup :PopupService = use_context();
-    let collector = use_signal(||{
-        (1..15)
-        .map(|id| Collector{
-            id: id.to_string(),
-            total_volume: 2.370,
-            total_volume_usd: 8147.63,
-            collector_id: "10FEO!20".to_string(),
-            owned: 2,
-            token_ids: vec!["1234567890".to_string(), "1234567890".to_string()],
-            wallet_address: "0x1234567890abcdef".to_string(),
-            last_activity: "2023-10-01".to_string(),
-            verified: true,
-        })
-        .collect::<Vec<_>>()
-    });
-   
- let asset = use_signal(||{
-    (0..8).map(|id| Assets{
+impl Controller {
+    pub fn new(lang: Language, agit_id: ReadOnlySignal<i64>) -> Result<Self, RenderError> {
+        let mut popup: PopupService = use_context();
+
+        let res = use_server_future(move || async move {
+            let endpoint = crate::config::get().api_url;
+            let client = CollectorModel::get_client(endpoint);
+            client
+                .query(CollectorQuery::new(100).with_page(0))
+                .await
+                .unwrap_or_default()
+        })?;
+        tracing::debug!("res: {:?}", res);
+
+        let collector = use_signal(|| {
+            (1..15)
+                .map(|id| Collector {
+                    id: id.to_string(),
+                    total_volume: 2.370,
+                    total_volume_usd: 8147.63,
+                    collector_id: "10FEO!20".to_string(),
+                    owned: 2,
+                    token_ids: vec!["1234567890".to_string(), "1234567890".to_string()],
+                    wallet_address: "0x1234567890abcdef".to_string(),
+                    last_activity: "2023-10-01".to_string(),
+                    verified: true,
+                })
+                .collect::<Vec<_>>()
+        });
+
+        let asset = use_signal(|| {
+            (0..8).map(|id| Assets{
         id : id.to_string(),
         title: "Asset Title".to_string(),
         artist_name: "Artist Name".to_string(),
@@ -63,26 +76,84 @@ impl Controller{
         rarity: "Rare".to_string(),
 
     }).collect::<Vec<_>>()
- });
+        });
 
- let activity = use_signal(||{
-    (0..6).map(|id|Activity{
-        id: id.to_string(),
-        from: "20114FWO".to_string(),
-        to: "20114FWO".to_string(),
-        time: "30 mins ago".to_string(),
-        title: "Art Title".to_string()
-    }).collect::<Vec<_>>()
- });
+        let activity = use_signal(|| {
+            (0..6)
+                .map(|id| Activity {
+                    id: id.to_string(),
+                    from: "20114FWO".to_string(),
+                    to: "20114FWO".to_string(),
+                    time: "30 mins ago".to_string(),
+                    title: "Art Title".to_string(),
+                })
+                .collect::<Vec<_>>()
+        });
 
-    let ctrl = Self{
-        lang,
-        collector,
-        popup,
-        asset,
-        activity
-    };
-    use_context_provider(||ctrl);
-    Ok(ctrl)
+        let ctrl = Self {
+            lang,
+            collector,
+            popup,
+            asset,
+            activity,
+        };
+        use_context_provider(|| ctrl);
+        Ok(ctrl)
+    }
+  pub fn create_collector(&self) {
+    spawn_local(async move{
+        let endpoint = crate::config::get().api_url;
+        let client = CollectorModel::get_client(endpoint);
+        let res = client.act(
+            common::tables::prelude::CollectorAction::Create(
+                CollectorCreateRequest {
+                    title: "".to_string(),
+                    description: "".to_string(),
+                    external_link: None,
+                    banner_url: "".to_string(),
+                    logo_url: "".to_string(),
+                },
+            )
+        ).await;
+        match res {
+            Ok(_) => {
+                tracing::debug!("Collector created successfully");
+            }
+            Err(err) => {
+                tracing::error!("Error creating collector: {:?}", err);
+            }
+            
+        }
+    });
   }
+
+  pub fn remove_collector(&self, collector_id:i64){
+
+   spawn_local(async move{
+    let endpoint = crate::config::get().api_url;
+    let client = CollectorModel::get_client(endpoint);
+    let res = client.act_by_id(
+        collector_id,
+        CollectorByIdAction::Delete(CollectorDeleteRequest {}),
+    ).await;
+    match res {
+        Ok(_) => {
+            tracing::debug!("Collector removed successfully");
+        }
+        Err(err) => {
+            tracing::error!("Error removing collector: {:?}", err);
+        }
+        
+    }
+
+   });
+
+
+
+
+  }
+  
+
+
+
 }

--- a/packages/build-ui/src/pages/agits/_id/management/mod.rs
+++ b/packages/build-ui/src/pages/agits/_id/management/mod.rs
@@ -9,7 +9,7 @@ mod model;
 
 
 
-pub use artists::{ArtistPage, ArtistDetailPage, NewArtistPage};
+pub use artists::{ArtistPage, ArtistDetailPage, NewArtistPage, EditArtistPage};
 pub use artworks::ArtworkPage;
 pub use collectors::{CollectorsPage, CollectorDetailPage};
 pub use collections::{CollectionPage, CollectionDetailPage};

--- a/packages/build-ui/src/pages/agits/_id/mod.rs
+++ b/packages/build-ui/src/pages/agits/_id/mod.rs
@@ -13,5 +13,5 @@ pub use page::HomePage;
 pub use design::DesignPage;
 pub use extension_tool::ExtensionToolPage;
 pub use hub::{DaoPage, FaqPage, OraclePage};
-pub use management::{ArtistPage, ArtworkPage, CollectionPage, CollectorsPage, CollectorDetailPage, CollectionDetailPage, ArtistDetailPage, NewArtistPage};
+pub use management::{ArtistPage, ArtworkPage, CollectionPage, CollectorsPage, CollectorDetailPage, CollectionDetailPage, ArtistDetailPage, NewArtistPage, EditArtistPage};
 pub use orders::{SalesRequestPage, ShippingLabelPage};

--- a/packages/build-ui/src/pages/agits/components/navigation/mod.rs
+++ b/packages/build-ui/src/pages/agits/components/navigation/mod.rs
@@ -24,6 +24,7 @@ enum SelectedItem {
     Artist,
     ArtistDetail,
     NewArtistPage,
+    EditArtistPage,
     Collectors,
     CollectorDetail,
     Dao,
@@ -71,6 +72,11 @@ fn check_route(route: Route) -> (SelectedSection, SelectedItem) {
             lang: _,
             agit_id: _,
         } => (SelectedSection::Management, SelectedItem::NewArtistPage),
+        Route::EditArtistPage {
+            lang: _,
+            agit_id: _,
+            artist_id: _,
+        } => (SelectedSection::Management, SelectedItem::EditArtistPage),
         Route::ArtistDetailPage {
             lang: _,
             agit_id: _,

--- a/packages/build-ui/src/routes.rs
+++ b/packages/build-ui/src/routes.rs
@@ -33,6 +33,8 @@ pub enum Route {
                         ArtistPage { lang: Language, agit_id: i64 },
                     #[route("/artists/:artist_id")]
                         ArtistDetailPage { lang: Language, agit_id: i64, artist_id: i64 },
+                    #[route("/artists/:artist_id/edit")]
+                        EditArtistPage { lang: Language, agit_id: i64, artist_id: i64 },
                     #[route("/artists/new")]
                         NewArtistPage { lang: Language, agit_id: i64},
                     #[route("/collectors")]  

--- a/packages/common/src/tables/collections/collections.rs
+++ b/packages/common/src/tables/collections/collections.rs
@@ -30,7 +30,7 @@ pub struct Collection {
     pub logo_url: String,
     #[api_model(summary, action_by_id = update)]
     pub authorized: bool,
-
+    
     #[api_model(summary, one_to_many = artworks, foreign_key = collection_id)]
     pub artworks: Vec<Artwork>,
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an "Edit Artist" page with a comprehensive interface for editing artist details including display name, social media, medium, theme, art style, introduction, and biography.
  - Enabled navigation from artist table rows to the "Edit Artist" page.
  - Added a multi-step modal dialog flow for confirming artist removal, including legal acknowledgment.
  - Added a "Remove Artist" confirmation modal accessible from artist settings.
  - Updated navigation and routing to support the new "Edit Artist" page with sidebar highlighting.
- **Enhancements**
  - Improved the "New Artist" page with modular input fields, localized labels, and a save icon on the save button.
  - Refined table row keys for better uniqueness and stability.
  - Expanded translation resources with new artist-related UI text for better localization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->